### PR TITLE
Update Console namespace

### DIFF
--- a/OpenSim/Framework/Console/CommandConsole.cs
+++ b/OpenSim/Framework/Console/CommandConsole.cs
@@ -38,7 +38,7 @@ using log4net;
 using OpenSim.Framework;
 using Nini.Config;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     public class Commands : ICommands
     {

--- a/OpenSim/Framework/Console/ConsoleBase.cs
+++ b/OpenSim/Framework/Console/ConsoleBase.cs
@@ -33,7 +33,7 @@ using System.Text;
 using System.Threading;
 using log4net;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     public class ConsoleLevel
     {

--- a/OpenSim/Framework/Console/ConsoleDisplayList.cs
+++ b/OpenSim/Framework/Console/ConsoleDisplayList.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// Used to generated a formatted table for the console.

--- a/OpenSim/Framework/Console/ConsoleDisplayTable.cs
+++ b/OpenSim/Framework/Console/ConsoleDisplayTable.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// Used to generated a formatted table for the console.

--- a/OpenSim/Framework/Console/ConsoleDisplayUtil.cs
+++ b/OpenSim/Framework/Console/ConsoleDisplayUtil.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// This will be a set of typical column sizes to allow greater consistency between console commands.

--- a/OpenSim/Framework/Console/ConsolePluginCommand.cs
+++ b/OpenSim/Framework/Console/ConsolePluginCommand.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     public delegate void ConsoleCommand(string[] comParams);
 

--- a/OpenSim/Framework/Console/ConsoleUtil.cs
+++ b/OpenSim/Framework/Console/ConsoleUtil.cs
@@ -33,7 +33,7 @@ using System.Reflection;
 using log4net;
 using OpenMetaverse;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     public class ConsoleUtil
     {

--- a/OpenSim/Framework/Console/LocalConsole.cs
+++ b/OpenSim/Framework/Console/LocalConsole.cs
@@ -36,7 +36,7 @@ using System.IO;
 using Nini.Config;
 using log4net;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// A console that uses cursor control and color

--- a/OpenSim/Framework/Console/MockConsole.cs
+++ b/OpenSim/Framework/Console/MockConsole.cs
@@ -32,7 +32,7 @@ using System.Text;
 using System.Xml;
 using Nini.Config;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// This is a Fake console that's used when setting up the Scene in Unit Tests

--- a/OpenSim/Framework/Console/OpenSimAppender.cs
+++ b/OpenSim/Framework/Console/OpenSimAppender.cs
@@ -29,7 +29,7 @@ using System;
 using log4net.Appender;
 using log4net.Core;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     /// <summary>
     /// Writes log information out onto the console

--- a/OpenSim/Framework/Console/RemoteConsole.cs
+++ b/OpenSim/Framework/Console/RemoteConsole.cs
@@ -37,7 +37,7 @@ using Nini.Config;
 using OpenSim.Framework.Servers.HttpServer;
 using log4net;
 
-namespace OpenSim.Framework.Console
+namespace MutSea.Framework.Console
 {
     // A console that uses REST interfaces
     //


### PR DESCRIPTION
## Summary
- switch `OpenSim.Framework.Console` namespaces to `MutSea.Framework.Console`

## Testing
- `nant test` *(fails: `nant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a734c76dc8332a128ac2f3a6a3174