### PR TITLE
Change Monitoring namespaces to MutSea

### DIFF
--- a/OpenSim/Framework/Monitoring/AssetStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/AssetStatsCollector.cs
@@ -30,7 +30,7 @@ using System.Timers;
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Asset service statistics collection

--- a/OpenSim/Framework/Monitoring/BaseStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/BaseStatsCollector.cs
@@ -31,7 +31,7 @@ using System.Text;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Statistics which all collectors are interested in reporting

--- a/OpenSim/Framework/Monitoring/Checks/Check.cs
+++ b/OpenSim/Framework/Monitoring/Checks/Check.cs
@@ -28,7 +28,7 @@
 using System;
 using System.Text;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     public class Check
     {

--- a/OpenSim/Framework/Monitoring/ChecksManager.cs
+++ b/OpenSim/Framework/Monitoring/ChecksManager.cs
@@ -32,7 +32,7 @@ using System.Reflection;
 using System.Text;
 using log4net;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Static class used to register/deregister checks on runtime conditions.

--- a/OpenSim/Framework/Monitoring/Interfaces/IPullStatsProvider.cs
+++ b/OpenSim/Framework/Monitoring/Interfaces/IPullStatsProvider.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Framework.Monitoring.Interfaces
+namespace MutSea.Interfaces
 {
     /// <summary>
     /// Implemented by objects which allow statistical information to be pulled from them.

--- a/OpenSim/Framework/Monitoring/Interfaces/IStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/Interfaces/IStatsCollector.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Implemented by classes which collect up non-viewer statistical information

--- a/OpenSim/Framework/Monitoring/JobEngine.cs
+++ b/OpenSim/Framework/Monitoring/JobEngine.cs
@@ -32,7 +32,7 @@ using System.Threading;
 using log4net;
 using OpenSim.Framework;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     public class JobEngine
     {

--- a/OpenSim/Framework/Monitoring/MemoryWatchdog.cs
+++ b/OpenSim/Framework/Monitoring/MemoryWatchdog.cs
@@ -32,7 +32,7 @@ using System.Reflection;
 using System.Threading;
 using log4net;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Experimental watchdog for memory usage.

--- a/OpenSim/Framework/Monitoring/ServerStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/ServerStatsCollector.cs
@@ -36,7 +36,7 @@ using log4net;
 using Nini.Config;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     public class ServerStatsCollector
     {

--- a/OpenSim/Framework/Monitoring/SimExtraStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/SimExtraStatsCollector.cs
@@ -33,10 +33,10 @@ using System.Linq;
 using System.Text;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework.Monitoring.Interfaces;
+using MutSea.Interfaces;
 
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Collects sim statistics which aren't already being collected for the linden viewer's statistics pane

--- a/OpenSim/Framework/Monitoring/Stats/CounterStat.cs
+++ b/OpenSim/Framework/Monitoring/Stats/CounterStat.cs
@@ -32,7 +32,7 @@ using System.Text;
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
 // A statistic that wraps a counter.
 // Built this way mostly so histograms and history can be created.

--- a/OpenSim/Framework/Monitoring/Stats/EventHistogram.cs
+++ b/OpenSim/Framework/Monitoring/Stats/EventHistogram.cs
@@ -32,7 +32,7 @@ using System.Text;
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
 // Create a time histogram of events. The histogram is built in a wrap-around
 //   array of equally distributed buckets.

--- a/OpenSim/Framework/Monitoring/Stats/PercentageStat.cs
+++ b/OpenSim/Framework/Monitoring/Stats/PercentageStat.cs
@@ -31,7 +31,7 @@ using System.Text;
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     public class PercentageStat : Stat
     {

--- a/OpenSim/Framework/Monitoring/Stats/Stat.cs
+++ b/OpenSim/Framework/Monitoring/Stats/Stat.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Text;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Holds individual statistic details

--- a/OpenSim/Framework/Monitoring/StatsLogger.cs
+++ b/OpenSim/Framework/Monitoring/StatsLogger.cs
@@ -33,7 +33,7 @@ using System.Text;
 using System.Timers;
 using log4net;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Provides a means to continuously log stats for debugging purposes.

--- a/OpenSim/Framework/Monitoring/StatsManager.cs
+++ b/OpenSim/Framework/Monitoring/StatsManager.cs
@@ -35,7 +35,7 @@ using System.Text;
 using OpenSim.Framework;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Static class used to register/deregister/fetch statistics

--- a/OpenSim/Framework/Monitoring/UserStatsCollector.cs
+++ b/OpenSim/Framework/Monitoring/UserStatsCollector.cs
@@ -29,7 +29,7 @@ using System.Timers;
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Collects user service statistics

--- a/OpenSim/Framework/Monitoring/Watchdog.cs
+++ b/OpenSim/Framework/Monitoring/Watchdog.cs
@@ -31,7 +31,7 @@ using System.Linq;
 using System.Threading;
 using log4net;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Manages launching threads and keeping watch over them for timeouts

--- a/OpenSim/Framework/Monitoring/WorkManager.cs
+++ b/OpenSim/Framework/Monitoring/WorkManager.cs
@@ -30,7 +30,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using log4net;
 
-namespace OpenSim.Framework.Monitoring
+namespace MutSea
 {
     /// <summary>
     /// Manages various work items in the simulator.


### PR DESCRIPTION
## Summary
- switch `OpenSim.Framework.Monitoring` namespaces to `MutSea`
- adjust internal reference in `SimExtraStatsCollector`

## Testing
- `nant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a734fb5908332a920b2fa49140fdd