### PR TITLE
Update server namespaces

### DIFF
--- a/OpenSim/Framework/Servers/BaseOpenSimServer.cs
+++ b/OpenSim/Framework/Servers/BaseOpenSimServer.cs
@@ -38,12 +38,12 @@ using log4net;
 using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Framework.Monitoring;
-using OpenSim.Framework.Servers.HttpServer;
+using MutSea.Framework.Servers.HttpServer;
 using Timer=System.Timers.Timer;
 using Nini.Config;
 using System.Runtime.InteropServices;
 
-namespace OpenSim.Framework.Servers
+namespace MutSea.Framework.Servers
 {
     /// <summary>
     /// Common base for the main OpenSimServers (user, grid, inventory, region, etc)

--- a/OpenSim/Framework/Servers/HttpServer/BaseHTTPHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHTTPHandler.cs
@@ -27,7 +27,7 @@
 
 using System.Collections;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public abstract class BaseHTTPHandler : BaseRequestHandler, IGenericHTTPHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseHttpServer.cs
@@ -48,7 +48,7 @@ using OpenSim.Framework.Monitoring;
 using OpenMetaverse.StructuredData;
 using OpenMetaverse;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class BaseHttpServer : IHttpServer
     {

--- a/OpenSim/Framework/Servers/HttpServer/BaseOutputStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseOutputStreamHandler.cs
@@ -27,7 +27,7 @@
 
 using System.IO;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// Base handler for writing to an output stream

--- a/OpenSim/Framework/Servers/HttpServer/BaseRequestHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseRequestHandler.cs
@@ -28,7 +28,7 @@
 using System;
 using OpenSim.Framework.Monitoring;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public abstract class BaseRequestHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/BaseStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseStreamHandler.cs
@@ -30,7 +30,7 @@ using System.IO;
 using System.Net;
 using OpenSim.Framework.ServiceAuth;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// Base streamed request handler.

--- a/OpenSim/Framework/Servers/HttpServer/BaseStreamHandlerBasicDOSProtector.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BaseStreamHandlerBasicDOSProtector.cs
@@ -28,7 +28,7 @@
 using System;
 using System.IO;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// BaseStreamHandlerBasicDOSProtector Base streamed request handler.

--- a/OpenSim/Framework/Servers/HttpServer/BinaryStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/BinaryStreamHandler.cs
@@ -28,7 +28,7 @@
 using System.IO;
 using System.Text;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate string BinaryMethod(byte[] data, string path, string param);
 

--- a/OpenSim/Framework/Servers/HttpServer/GenericHTTPBasicDOSProtector.cs
+++ b/OpenSim/Framework/Servers/HttpServer/GenericHTTPBasicDOSProtector.cs
@@ -27,7 +27,7 @@
 
 using System.Collections;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class GenericHTTPDOSProtector
     {

--- a/OpenSim/Framework/Servers/HttpServer/GenericHTTPMethod.cs
+++ b/OpenSim/Framework/Servers/HttpServer/GenericHTTPMethod.cs
@@ -27,7 +27,7 @@
 
 using System.Collections;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate Hashtable GenericHTTPMethod(Hashtable request);
 }

--- a/OpenSim/Framework/Servers/HttpServer/Interfaces/IHttpAgentHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/Interfaces/IHttpAgentHandler.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public interface IHttpAgentHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/Interfaces/IHttpServer.cs
+++ b/OpenSim/Framework/Servers/HttpServer/Interfaces/IHttpServer.cs
@@ -27,7 +27,7 @@
 
 using Nwc.XmlRpc;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// Interface to OpenSimulator's built in HTTP server.  Use this to register handlers (http, llsd, xmlrpc, etc.)

--- a/OpenSim/Framework/Servers/HttpServer/Interfaces/IOSHttpRequest.cs
+++ b/OpenSim/Framework/Servers/HttpServer/Interfaces/IOSHttpRequest.cs
@@ -34,7 +34,7 @@ using System.Net;
 using System.Text;
 using System.Web;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public interface IOSHttpRequest
     {

--- a/OpenSim/Framework/Servers/HttpServer/Interfaces/IOSHttpResponse.cs
+++ b/OpenSim/Framework/Servers/HttpServer/Interfaces/IOSHttpResponse.cs
@@ -33,7 +33,7 @@ using System.Net;
 using System.Text;
 using System.Web;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public interface IOSHttpResponse
     {

--- a/OpenSim/Framework/Servers/HttpServer/Interfaces/IStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/Interfaces/IStreamHandler.cs
@@ -29,7 +29,7 @@ using System.Collections;
 using System.IO;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public interface IRequestHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/JsonRPCMethod.cs
+++ b/OpenSim/Framework/Servers/HttpServer/JsonRPCMethod.cs
@@ -28,7 +28,7 @@
 using System.Net;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate bool JsonRPCMethod(OSDMap jsonRpcRequest, ref JsonRpcResponse response);
 }

--- a/OpenSim/Framework/Servers/HttpServer/JsonRpcRequestManager.cs
+++ b/OpenSim/Framework/Servers/HttpServer/JsonRpcRequestManager.cs
@@ -35,7 +35,7 @@ using OpenMetaverse.StructuredData;
 using OpenMetaverse;
 using log4net;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// Json rpc request manager.

--- a/OpenSim/Framework/Servers/HttpServer/JsonRpcResponse.cs
+++ b/OpenSim/Framework/Servers/HttpServer/JsonRpcResponse.cs
@@ -28,7 +28,7 @@ using System;
 using System.Net;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public sealed class ErrorCode
     {

--- a/OpenSim/Framework/Servers/HttpServer/LLSDMethod.cs
+++ b/OpenSim/Framework/Servers/HttpServer/LLSDMethod.cs
@@ -28,7 +28,7 @@
 using System.Net;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate OSD LLSDMethod(string path, OSD request, string endpoint);
     public delegate OSD DefaultLLSDMethod(OSD request, IPEndPoint client);

--- a/OpenSim/Framework/Servers/HttpServer/LLSDMethodString.cs
+++ b/OpenSim/Framework/Servers/HttpServer/LLSDMethodString.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate OSD LLSDMethodString(OSD request, string thePath);
 }

--- a/OpenSim/Framework/Servers/HttpServer/OSHttpRequest.cs
+++ b/OpenSim/Framework/Servers/HttpServer/OSHttpRequest.cs
@@ -38,7 +38,7 @@ using log4net;
 
 using System.Runtime.CompilerServices;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class OSHttpRequest : IOSHttpRequest
     {

--- a/OpenSim/Framework/Servers/HttpServer/OSHttpResponse.cs
+++ b/OpenSim/Framework/Servers/HttpServer/OSHttpResponse.cs
@@ -31,7 +31,7 @@ using System.Text;
 using OSHttpServer;
 using System.Runtime.CompilerServices;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// OSHttpResponse is the OpenSim representation of an HTTP

--- a/OpenSim/Framework/Servers/HttpServer/PollServiceEventArgs.cs
+++ b/OpenSim/Framework/Servers/HttpServer/PollServiceEventArgs.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections;
 using OpenMetaverse;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate OSHttpResponse RequestMethod(UUID ID, OSHttpRequest request);
     public delegate bool HasEventsMethod(UUID requestID, UUID pId);

--- a/OpenSim/Framework/Servers/HttpServer/PollServiceHttpRequest.cs
+++ b/OpenSim/Framework/Servers/HttpServer/PollServiceHttpRequest.cs
@@ -35,7 +35,7 @@ using OSHttpServer;
 using log4net;
 using OpenMetaverse;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class PollServiceHttpRequest
     {

--- a/OpenSim/Framework/Servers/HttpServer/PollServiceRequestManager.cs
+++ b/OpenSim/Framework/Servers/HttpServer/PollServiceRequestManager.cs
@@ -35,7 +35,7 @@ using Amib.Threading;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class PollServiceRequestManager
     {

--- a/OpenSim/Framework/Servers/HttpServer/RestDeserialiseHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestDeserialiseHandler.cs
@@ -29,7 +29,7 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate TResponse RestDeserialiseMethod<TRequest, TResponse>(TRequest request);
 

--- a/OpenSim/Framework/Servers/HttpServer/RestHTTPHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestHTTPHandler.cs
@@ -27,7 +27,7 @@
 
 using System.Collections;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class RestHTTPHandler : BaseHTTPHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/RestMethod.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestMethod.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate string RestMethod(string request, string path, string param,
                                       IOSHttpRequest httpRequest, IOSHttpResponse httpResponse);

--- a/OpenSim/Framework/Servers/HttpServer/RestObjectPoster.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestObjectPoster.cs
@@ -32,7 +32,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// Makes an asynchronous REST request which doesn't require us to do anything with the response.

--- a/OpenSim/Framework/Servers/HttpServer/RestObjectPosterResponse.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestObjectPosterResponse.cs
@@ -32,7 +32,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate void ReturnResponse<T>(T reponse);
 

--- a/OpenSim/Framework/Servers/HttpServer/RestSessionService.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestSessionService.cs
@@ -34,7 +34,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using log4net;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class RestSessionObject<TRequest>
     {

--- a/OpenSim/Framework/Servers/HttpServer/RestStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/RestStreamHandler.cs
@@ -28,7 +28,7 @@
 using System.IO;
 using System.Text;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class RestStreamHandler : BaseStreamHandler
     {

--- a/OpenSim/Framework/Servers/HttpServer/SimpleBaseRequestHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/SimpleBaseRequestHandler.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// simple Base streamed request handler

--- a/OpenSim/Framework/Servers/HttpServer/SimpleBinaryHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/SimpleBinaryHandler.cs
@@ -30,7 +30,7 @@ using System.IO;
 using OpenSim.Framework.ServiceAuth;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// simple OSD streamed request handler.

--- a/OpenSim/Framework/Servers/HttpServer/SimpleOSDMapHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/SimpleOSDMapHandler.cs
@@ -29,7 +29,7 @@ using System.Net;
 using OpenSim.Framework.ServiceAuth;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// simple OSD streamed request handler.

--- a/OpenSim/Framework/Servers/HttpServer/SimpleStreamHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/SimpleStreamHandler.cs
@@ -29,7 +29,7 @@ using System;
 using System.Net;
 using OpenSim.Framework.ServiceAuth;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     /// <summary>
     /// simple Base streamed request handler.

--- a/OpenSim/Framework/Servers/HttpServer/WebsocketServerHandler.cs
+++ b/OpenSim/Framework/Servers/HttpServer/WebsocketServerHandler.cs
@@ -34,7 +34,7 @@ using System.Text;
 using System.Threading;
 using OSHttpServer;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     // Sealed class.  If you're going to unseal it, implement IDisposable.
     /// <summary>

--- a/OpenSim/Framework/Servers/HttpServer/XmlRpcBasicDOSProtector.cs
+++ b/OpenSim/Framework/Servers/HttpServer/XmlRpcBasicDOSProtector.cs
@@ -30,7 +30,7 @@ using Nwc.XmlRpc;
 using OpenSim.Framework;
 
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public class XmlRpcBasicDOSProtector
     {

--- a/OpenSim/Framework/Servers/HttpServer/XmlRpcMethod.cs
+++ b/OpenSim/Framework/Servers/HttpServer/XmlRpcMethod.cs
@@ -28,7 +28,7 @@
 using System.Net;
 using Nwc.XmlRpc;
 
-namespace OpenSim.Framework.Servers.HttpServer
+namespace MutSea.Framework.Servers.HttpServer
 {
     public delegate XmlRpcResponse XmlRpcMethod(XmlRpcRequest request, IPEndPoint client);
 }

--- a/OpenSim/Framework/Servers/MainServer.cs
+++ b/OpenSim/Framework/Servers/MainServer.cs
@@ -33,9 +33,9 @@ using System.Text;
 using log4net;
 using OpenSim.Framework;
 using OpenSim.Framework.Console;
-using OpenSim.Framework.Servers.HttpServer;
+using MutSea.Framework.Servers.HttpServer;
 
-namespace OpenSim.Framework.Servers
+namespace MutSea.Framework.Servers
 {
     public class MainServer
     {

--- a/OpenSim/Framework/Servers/ServerBase.cs
+++ b/OpenSim/Framework/Servers/ServerBase.cs
@@ -43,7 +43,7 @@ using Nini.Config;
 using OpenSim.Framework.Console;
 using OpenSim.Framework.Monitoring;
 
-namespace OpenSim.Framework.Servers
+namespace MutSea.Framework.Servers
 {
     public class ServerBase
     {

--- a/OpenSim/Framework/Servers/Tests/VersionInfoTests.cs
+++ b/OpenSim/Framework/Servers/Tests/VersionInfoTests.cs
@@ -31,7 +31,7 @@ using System.Text;
 using NUnit.Framework;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Framework.Servers.Tests
+namespace MutSea.Framework.Servers.Tests
 {
     [TestFixture]
     public class VersionInfoTests : OpenSimTestCase


### PR DESCRIPTION
## Summary
- rename `OpenSim.Framework.Servers` namespaces to `MutSea.Framework.Servers`
- update HttpServer submodule namespaces

## Testing
- `make test` *(fails: dotnet and nant not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a73527f1c83328dfcecb0b44bbe18