### PR TITLE
Fix framework tests namespace

### DIFF
--- a/OpenSim/Framework/Tests/AgentCircuitDataTest.cs
+++ b/OpenSim/Framework/Tests/AgentCircuitDataTest.cs
@@ -29,9 +29,9 @@ using System.Collections.Generic;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using NUnit.Framework;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class AgentCircuitDataTest : OpenSimTestCase

--- a/OpenSim/Framework/Tests/AgentCircuitManagerTests.cs
+++ b/OpenSim/Framework/Tests/AgentCircuitManagerTests.cs
@@ -29,7 +29,7 @@ using OpenMetaverse;
 using NUnit.Framework;
 using System;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class AgentCircuitManagerTests

--- a/OpenSim/Framework/Tests/AnimationTests.cs
+++ b/OpenSim/Framework/Tests/AnimationTests.cs
@@ -31,10 +31,10 @@ using NUnit.Framework;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using OpenSim.Framework;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 using Animation = OpenSim.Framework.Animation;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class AnimationTests : OpenSimTestCase

--- a/OpenSim/Framework/Tests/AssetBaseTest.cs
+++ b/OpenSim/Framework/Tests/AssetBaseTest.cs
@@ -30,9 +30,9 @@ using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class AssetBaseTest : OpenSimTestCase

--- a/OpenSim/Framework/Tests/CacheTests.cs
+++ b/OpenSim/Framework/Tests/CacheTests.cs
@@ -28,9 +28,9 @@
 using System;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class CacheTests : OpenSimTestCase

--- a/OpenSim/Framework/Tests/LocationTest.cs
+++ b/OpenSim/Framework/Tests/LocationTest.cs
@@ -26,9 +26,9 @@
  */
 
 using NUnit.Framework;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class LocationTest : OpenSimTestCase

--- a/OpenSim/Framework/Tests/MundaneFrameworkTests.cs
+++ b/OpenSim/Framework/Tests/MundaneFrameworkTests.cs
@@ -32,9 +32,9 @@ using OpenMetaverse.StructuredData;
 using System;
 using System.Globalization;
 using System.Threading;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class MundaneFrameworkTests : OpenSimTestCase

--- a/OpenSim/Framework/Tests/PrimeNumberHelperTests.cs
+++ b/OpenSim/Framework/Tests/PrimeNumberHelperTests.cs
@@ -31,9 +31,9 @@ using NUnit.Framework;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using OpenSim.Framework;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class PrimeNumberHelperTests : OpenSimTestCase

--- a/OpenSim/Framework/Tests/UtilTest.cs
+++ b/OpenSim/Framework/Tests/UtilTest.cs
@@ -28,9 +28,9 @@
 using System;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Tests.Common;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Framework.Tests
+namespace MutSea.Framework.Tests
 {
     [TestFixture]
     public class UtilTests : OpenSimTestCase


### PR DESCRIPTION
## Summary
- update `using` directives
- update namespace declarations in framework tests

## Testing
- `nant test` *(fails: `nant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a735b830c8332bb466091a58905ae