### PR TITLE
Prefix data test namespaces

### DIFF
--- a/OpenSim/Data/Tests/AssetTests.cs
+++ b/OpenSim/Data/Tests/AssetTests.cs
@@ -43,7 +43,7 @@ using OpenSim.Data.MySQL;
 using Mono.Data.Sqlite;
 using OpenSim.Data.SQLite;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     [TestFixture(Description = "Asset store tests (SQLite)")]
     public class SQLiteAssetTests :  AssetTests<SqliteConnection, SQLiteAssetData>

--- a/OpenSim/Data/Tests/BasicDataServiceTest.cs
+++ b/OpenSim/Data/Tests/BasicDataServiceTest.cs
@@ -39,7 +39,7 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     /// <summary>This is a base class for testing any Data service for any DBMS.
     /// Requires NUnit 2.5 or better (to support the generics).

--- a/OpenSim/Data/Tests/DataTestUtil.cs
+++ b/OpenSim/Data/Tests/DataTestUtil.cs
@@ -31,7 +31,7 @@ using System.Text;
 using OpenMetaverse;
 using NUnit.Framework;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     /// <summary>
     /// Shared constants and methods for database unit tests.

--- a/OpenSim/Data/Tests/DefaultTestConns.cs
+++ b/OpenSim/Data/Tests/DefaultTestConns.cs
@@ -33,7 +33,7 @@ using System.Reflection;
 using System.IO;
 using Nini.Config;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     /// <summary>This static class looks for TestDataConnections.ini file in the /bin directory to obtain
     /// a connection string for testing one of the supported databases.

--- a/OpenSim/Data/Tests/EstateTests.cs
+++ b/OpenSim/Data/Tests/EstateTests.cs
@@ -44,7 +44,7 @@ using OpenSim.Data.MySQL;
 using Mono.Data.Sqlite;
 using OpenSim.Data.SQLite;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     [TestFixture(Description = "Estate store tests (SQLite)")]
     public class SQLiteEstateTests : EstateTests<SqliteConnection, SQLiteEstateStore>

--- a/OpenSim/Data/Tests/InventoryTests.cs
+++ b/OpenSim/Data/Tests/InventoryTests.cs
@@ -42,7 +42,7 @@ using OpenSim.Data.MySQL;
 using Mono.Data.Sqlite;
 using OpenSim.Data.SQLite;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     [TestFixture(Description = "Inventory store tests (MySQL)")]
     public class MySqlInventoryTests : InventoryTests<MySqlConnection, MySQLInventoryData>

--- a/OpenSim/Data/Tests/PropertyCompareConstraint.cs
+++ b/OpenSim/Data/Tests/PropertyCompareConstraint.cs
@@ -38,7 +38,7 @@ using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     public static class Constraints
     {

--- a/OpenSim/Data/Tests/PropertyScrambler.cs
+++ b/OpenSim/Data/Tests/PropertyScrambler.cs
@@ -36,7 +36,7 @@ using OpenMetaverse;
 using OpenSim.Framework;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     //This is generic so that the lambda expressions will work right in IDEs.
     public class PropertyScrambler<T>

--- a/OpenSim/Data/Tests/RegionTests.cs
+++ b/OpenSim/Data/Tests/RegionTests.cs
@@ -48,7 +48,7 @@ using OpenSim.Data.MySQL;
 using Mono.Data.Sqlite;
 using OpenSim.Data.SQLite;
 
-namespace OpenSim.Data.Tests
+namespace MutSea.OpenSim.Data.Tests
 {
     [TestFixture(Description = "Region store tests (SQLite)")]
     public class SQLiteRegionTests : RegionTests<SqliteConnection, SQLiteSimulationData>


### PR DESCRIPTION
## Summary
- prepend `MutSea` to test namespaces under `OpenSim/Data/Tests`

## Testing
- `nant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7a3c901c83328bd1e7ff8be6719b