### PR TITLE
Add GitHub C# ignores without removing existing rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,28 @@ doc/doxygen.error.log
 bin/OpenSim.ini
 
 *.patch
+# Additional ignore rules for C# projects (GitHub VisualStudio template)
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+.vscode/
+*.userprefs
+*.userosscache
+*.sln.docstates
+*.exe
+*.app
+*.cache
+[Tt]humbs.db
+[Dd]esktop.ini
+*.psess
+*.vsp
+*.vspx
+*.coverage
+*.coveragexml
+_ReSharper*/
+*.DotSettings.user
+*.nupkg
+packages/
+
+# Explicitly track IDE directory
+!.ide/


### PR DESCRIPTION
## Summary
- restore original repository `.gitignore`
- append standard C# ignore rules from GitHub template
- explicitly track `.ide` directory

## Testing
- `nant test` *(fails: `nant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a630fa65083328211d3bb1a42d3cc