### PR TITLE
Update namespaces for region application

### DIFF
--- a/OpenSim/Region/Application/Application.cs
+++ b/OpenSim/Region/Application/Application.cs
@@ -35,7 +35,7 @@ using Nini.Config;
 using OpenSim.Framework;
 using OpenSim.Framework.Console;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// Starting class for the OpenSimulator Region

--- a/OpenSim/Region/Application/ConfigurationLoader.cs
+++ b/OpenSim/Region/Application/ConfigurationLoader.cs
@@ -35,7 +35,7 @@ using log4net;
 using Nini.Config;
 using OpenSim.Framework;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// Loads the Configuration files into nIni

--- a/OpenSim/Region/Application/IApplicationPlugin.cs
+++ b/OpenSim/Region/Application/IApplicationPlugin.cs
@@ -28,7 +28,7 @@
 using OpenSim.Framework;
 using Mono.Addins;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// OpenSimulator Application Plugin framework interface

--- a/OpenSim/Region/Application/OpenSim.cs
+++ b/OpenSim/Region/Application/OpenSim.cs
@@ -51,7 +51,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using OpenSim.Framework.Servers.HttpServer;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// Interactive OpenSim region server

--- a/OpenSim/Region/Application/OpenSimBackground.cs
+++ b/OpenSim/Region/Application/OpenSimBackground.cs
@@ -30,7 +30,7 @@ using System.Threading;
 using log4net;
 using Nini.Config;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// Consoleless OpenSimulator region server

--- a/OpenSim/Region/Application/OpenSimBase.cs
+++ b/OpenSim/Region/Application/OpenSimBase.cs
@@ -50,7 +50,7 @@ using OpenSim.Services.Base;
 using OpenSim.Services.Interfaces;
 using OpenSim.Services.UserAccountService;
 
-namespace OpenSim
+namespace MutSea
 {
     /// <summary>
     /// Common OpenSimulator simulator code

--- a/OpenSim/Region/Application/RegionApplicationBase.cs
+++ b/OpenSim/Region/Application/RegionApplicationBase.cs
@@ -40,7 +40,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.PhysicsModules.SharedBase;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim
+namespace MutSea
 {
     public abstract class RegionApplicationBase : BaseOpenSimServer
     {


### PR DESCRIPTION
## Summary
- rename `namespace OpenSim` to `namespace MutSea` in region application classes

## Testing
- `make test` *(fails: `dotnet: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c553fcc83329e26a68f3a4e0b94