### PR TITLE
Update namespaces under CoreModules and Properties

### DIFF
--- a/OpenSim/Addons/Groups/Properties/AssemblyInfo.cs
+++ b/OpenSim/Addons/Groups/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using Mono.Addins;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Addons.Groups")]
+[assembly: AssemblyTitle("MutSea.Addons.Groups")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Addons/OfflineIM/Properties/AssemblyInfo.cs
+++ b/OpenSim/Addons/OfflineIM/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using Mono.Addins;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Addons.OfflineIM")]
+[assembly: AssemblyTitle("MutSea.Addons.OfflineIM")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/ApplicationPlugins/LoadRegions/Properties/AssemblyInfo.cs
+++ b/OpenSim/ApplicationPlugins/LoadRegions/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using Mono.Addins;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly : AssemblyTitle("OpenSim.ApplicationPlugins.LoadRegions")]
+[assembly : AssemblyTitle("MutSea.ApplicationPlugins.LoadRegions")]
 [assembly : AssemblyDescription("")]
 [assembly : AssemblyConfiguration("")]
 [assembly : AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/ApplicationPlugins/RegionModulesController/Properties/AssemblyInfo.cs
+++ b/OpenSim/ApplicationPlugins/RegionModulesController/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using Mono.Addins;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.ApplicationPlugins.RegionModulesController")]
+[assembly: AssemblyTitle("MutSea.ApplicationPlugins.RegionModulesController")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/ApplicationPlugins/RemoteController/Properties/AssemblyInfo.cs
+++ b/OpenSim/ApplicationPlugins/RemoteController/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using Mono.Addins;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.ApplicationPlugins.RemoteController")]
+[assembly: AssemblyTitle("MutSea.ApplicationPlugins.RemoteController")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Capabilities/Handlers/Properties/AssemblyInfo.cs
+++ b/OpenSim/Capabilities/Handlers/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Capabilities.Handlers")]
+[assembly: AssemblyTitle("MutSea.Capabilities.Handlers")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Capabilities/Properties/AssemblyInfo.cs
+++ b/OpenSim/Capabilities/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Capabilities")]
+[assembly: AssemblyTitle("MutSea.Capabilities")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/ConsoleClient/Properties/AssemblyInfo.cs
+++ b/OpenSim/ConsoleClient/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.ConsoleClient")]
+[assembly: AssemblyTitle("MutSea.ConsoleClient")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Data/Properties/AssemblyInfo.cs
+++ b/OpenSim/Data/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly : AssemblyTitle("OpenSim.Data")]
+[assembly : AssemblyTitle("MutSea.Data")]
 [assembly : AssemblyDescription("")]
 [assembly : AssemblyConfiguration("")]
 [assembly : AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Region/CoreModules/Framework/Caps/CapabilitiesModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/Caps/CapabilitiesModule.cs
@@ -40,7 +40,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using Caps=OpenSim.Framework.Capabilities.Caps;
 
-namespace OpenSim.Region.CoreModules.Framework
+namespace MutSea.Region.CoreModules.Framework
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "CapabilitiesModule")]
     public class CapabilitiesModule : INonSharedRegionModule, ICapabilitiesModule

--- a/OpenSim/Region/CoreModules/Framework/DynamicAttributes/DAExampleModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/DynamicAttributes/DAExampleModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Region.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.DynamicAttributes.DAExampleModule
+namespace MutSea.Region.CoreModules.Framework.DynamicAttributes.DAExampleModule
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "DAExampleModule")]
     public class DAExampleModule : INonSharedRegionModule

--- a/OpenSim/Region/CoreModules/Framework/DynamicAttributes/DOExampleModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/DynamicAttributes/DOExampleModule.cs
@@ -36,11 +36,11 @@ using OpenMetaverse.Packets;
 using OpenMetaverse.StructuredData;
 using OpenSim.Framework;
 using OpenSim.Region.Framework;
-using OpenSim.Region.CoreModules.Framework.DynamicAttributes.DAExampleModule;
+using MutSea.Region.CoreModules.Framework.DynamicAttributes.DAExampleModule;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.DynamicAttributes.DOExampleModule
+namespace MutSea.Region.Framework.DynamicAttributes.DOExampleModule
 {
     /// <summary>
     /// Example module for experimenting with and demonstrating dynamic object ideas.

--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferModule.cs
@@ -46,7 +46,7 @@ using log4net;
 using Nini.Config;
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
+namespace MutSea.Region.CoreModules.Framework.EntityTransfer
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "EntityTransferModule")]
     public class EntityTransferModule : INonSharedRegionModule, IEntityTransferModule, IDisposable

--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferStateMachine.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/EntityTransferStateMachine.cs
@@ -42,7 +42,7 @@ using OpenSim.Region.PhysicsModules.SharedBase;
 using OpenSim.Services.Interfaces;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
+namespace MutSea.Region.CoreModules.Framework.EntityTransfer
 {
     /// <summary>
     /// The possible states that an agent can be in when its being transferred between regions.

--- a/OpenSim/Region/CoreModules/Framework/EntityTransfer/HGEntityTransferModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/EntityTransfer/HGEntityTransferModule.cs
@@ -46,7 +46,7 @@ using Mono.Addins;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 
 
-namespace OpenSim.Region.CoreModules.Framework.EntityTransfer
+namespace MutSea.Region.CoreModules.Framework.EntityTransfer
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "HGEntityTransferModule")]
     public class HGEntityTransferModule : EntityTransferModule, IUserAgentVerificationModule

--- a/OpenSim/Region/CoreModules/Framework/InterfaceCommander/Command.cs
+++ b/OpenSim/Region/CoreModules/Framework/InterfaceCommander/Command.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using OpenSim.Region.Framework.Interfaces;
 using OpenMetaverse;
 
-namespace OpenSim.Region.CoreModules.Framework.InterfaceCommander
+namespace MutSea.Region.CoreModules.Framework.InterfaceCommander
 {
     /// <summary>
     /// A single function call encapsulated in a class which enforces arguments when passing around as Object[]'s.

--- a/OpenSim/Region/CoreModules/Framework/InterfaceCommander/Commander.cs
+++ b/OpenSim/Region/CoreModules/Framework/InterfaceCommander/Commander.cs
@@ -33,7 +33,7 @@ using log4net;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.CoreModules.Framework.InterfaceCommander
+namespace MutSea.Region.CoreModules.Framework.InterfaceCommander
 {
     /// <summary>
     /// A class to enable modules to register console and script commands, which enforces typing and valid input.

--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGAssetMapper.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGAssetMapper.cs
@@ -38,7 +38,7 @@ using OpenSim.Framework.Serialization.External;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.CoreModules.Framework.InventoryAccess
+namespace MutSea.Region.CoreModules.Framework.InventoryAccess
 {
     public class HGAssetMapper
     {

--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
@@ -40,7 +40,7 @@ using log4net;
 using Nini.Config;
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Framework.InventoryAccess
+namespace MutSea.Region.CoreModules.Framework.InventoryAccess
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "HGInventoryAccessModule")]
     public class HGInventoryAccessModule : BasicInventoryAccessModule, INonSharedRegionModule, IInventoryAccessModule

--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/InventoryAccessModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/InventoryAccessModule.cs
@@ -42,7 +42,7 @@ using Nini.Config;
 using Mono.Addins;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.CoreModules.Framework.InventoryAccess
+namespace MutSea.Region.CoreModules.Framework.InventoryAccess
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "BasicInventoryAccessModule")]
     public class BasicInventoryAccessModule : INonSharedRegionModule, IInventoryAccessModule

--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/Tests/HGAssetMapperTests.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/Tests/HGAssetMapperTests.cs
@@ -32,13 +32,13 @@ using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
 using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Framework.InventoryAccess;
+using MutSea.Region.CoreModules.Framework.InventoryAccess;
 using OpenSim.Region.Framework.Scenes;
 //using OpenSim.Region.ScriptEngine.XEngine;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.CoreModules.Framework.InventoryAccess.Tests
+namespace MutSea.Region.CoreModules.Framework.InventoryAccess.Tests
 {
     [TestFixture]
     public class HGAssetMapperTests : OpenSimTestCase

--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/Tests/InventoryAccessModuleTests.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/Tests/InventoryAccessModuleTests.cs
@@ -38,13 +38,13 @@ using OpenSim.Framework;
 using OpenSim.Framework.Serialization;
 using OpenSim.Framework.Serialization.External;
 using OpenSim.Region.CoreModules.Avatar.Inventory.Archiver;
-using OpenSim.Region.CoreModules.Framework.InventoryAccess;
+using MutSea.Region.CoreModules.Framework.InventoryAccess;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Scenes.Serialization;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.CoreModules.Framework.InventoryAccess.Tests
+namespace MutSea.Region.CoreModules.Framework.InventoryAccess.Tests
 {
     [TestFixture]
     public class InventoryAccessModuleTests : OpenSimTestCase

--- a/OpenSim/Region/CoreModules/Framework/Library/LibraryModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/Library/LibraryModule.cs
@@ -44,7 +44,7 @@ using Mono.Addins;
 using Nini.Config;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.CoreModules.Framework.Library
+namespace MutSea.Region.CoreModules.Framework.Library
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "LibraryModule")]
     public class LibraryModule : ISharedRegionModule

--- a/OpenSim/Region/CoreModules/Framework/Library/LocalInventoryService.cs
+++ b/OpenSim/Region/CoreModules/Framework/Library/LocalInventoryService.cs
@@ -35,7 +35,7 @@ using OpenSim.Services.Interfaces;
 using OpenMetaverse;
 using log4net;
 
-namespace OpenSim.Region.CoreModules.Framework.Library
+namespace MutSea.Region.CoreModules.Framework.Library
 {
     public class LocalInventoryService : IInventoryService
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Alerts/DeadlockAlert.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Alerts/DeadlockAlert.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Region.CoreModules.Framework.Monitoring.Monitors;
+using MutSea.Region.CoreModules.Framework.Monitoring.Monitors;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Alerts
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Alerts
 {
     class DeadlockAlert : IAlert
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/IAlert.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/IAlert.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring
+namespace MutSea.Region.CoreModules.Framework.Monitoring
 {
     internal delegate void Alert(Type reporter, string reason, bool fatal);
 

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/IMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/IMonitor.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring
+namespace MutSea.Region.CoreModules.Framework.Monitoring
 {
     interface IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/MonitorModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/MonitorModule.cs
@@ -37,13 +37,13 @@ using OpenSim.Framework;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Framework.Servers;
 using OpenSim.Framework.Servers.HttpServer;
-using OpenSim.Region.CoreModules.Framework.Monitoring.Alerts;
-using OpenSim.Region.CoreModules.Framework.Monitoring.Monitors;
+using MutSea.Region.CoreModules.Framework.Monitoring.Alerts;
+using MutSea.Region.CoreModules.Framework.Monitoring.Monitors;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring
+namespace MutSea.Region.CoreModules.Framework.Monitoring
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "MonitorModule")]
     public class MonitorModule : INonSharedRegionModule

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/AgentCountMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/AgentCountMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class AgentCountMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ChildAgentCountMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ChildAgentCountMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class ChildAgentCountMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/EventFrameMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/EventFrameMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class EventFrameMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/GCMemoryMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/GCMemoryMonitor.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class GCMemoryMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/GenericMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/GenericMonitor.cs
@@ -28,7 +28,7 @@
 using System;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class GenericMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/LandFrameMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/LandFrameMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class LandFrameMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/LastFrameTimeMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/LastFrameTimeMonitor.cs
@@ -28,7 +28,7 @@
 using System;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class LastFrameTimeMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ObjectCountMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ObjectCountMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class ObjectCountMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PWSMemoryMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PWSMemoryMonitor.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class PWSMemoryMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PhysicsFrameMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PhysicsFrameMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class PhysicsFrameMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PhysicsUpdateFrameMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/PhysicsUpdateFrameMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class PhysicsUpdateFrameMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ThreadCountMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/ThreadCountMonitor.cs
@@ -26,7 +26,7 @@
  */
 
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class ThreadCountMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/TotalFrameMonitor.cs
+++ b/OpenSim/Region/CoreModules/Framework/Monitoring/Monitors/TotalFrameMonitor.cs
@@ -27,7 +27,7 @@
 
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Framework.Monitoring.Monitors
+namespace MutSea.Region.CoreModules.Framework.Monitoring.Monitors
 {
     class TotalFrameMonitor : IMonitor
     {

--- a/OpenSim/Region/CoreModules/Framework/Search/BasicSearchModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/Search/BasicSearchModule.cs
@@ -48,7 +48,7 @@ using Mono.Addins;
 
 using DirFindFlags = OpenMetaverse.DirectoryManager.DirFindFlags;
 
-namespace OpenSim.Region.CoreModules.Framework.Search
+namespace MutSea.Region.CoreModules.Framework.Search
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "BasicSearchModule")]
     public class BasicSearchModule : ISharedRegionModule

--- a/OpenSim/Region/CoreModules/Framework/ServiceThrottle/ServiceThrottleModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/ServiceThrottle/ServiceThrottleModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Scenes;
 using GridRegion = OpenSim.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.CoreModules.Framework
+namespace MutSea.Region.CoreModules.Framework
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "GridServiceThrottleModule")]
     public class ServiceThrottleModule : ISharedRegionModule, IServiceThrottleModule

--- a/OpenSim/Region/CoreModules/Framework/UserManagement/HGUserManagementModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/UserManagement/HGUserManagementModule.cs
@@ -43,7 +43,7 @@ using log4net;
 using Nini.Config;
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Framework.UserManagement
+namespace MutSea.Region.CoreModules.Framework.UserManagement
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "HGUserManagementModule")]
     public class HGUserManagementModule : UserManagementModule, ISharedRegionModule, IUserManagement

--- a/OpenSim/Region/CoreModules/Framework/UserManagement/Tests/HGUserManagementModuleTests.cs
+++ b/OpenSim/Region/CoreModules/Framework/UserManagement/Tests/HGUserManagementModuleTests.cs
@@ -30,10 +30,10 @@ using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
 using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Framework.UserManagement;
+using MutSea.Region.CoreModules.Framework.UserManagement;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.CoreModules.Framework.UserManagement.Tests
+namespace MutSea.Region.CoreModules.Framework.UserManagement.Tests
 {
     [TestFixture]
     public class HGUserManagementModuleTests : OpenSimTestCase

--- a/OpenSim/Region/CoreModules/Framework/UserManagement/UserManagementModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/UserManagement/UserManagementModule.cs
@@ -44,7 +44,7 @@ using Nini.Config;
 using Mono.Addins;
 
 
-namespace OpenSim.Region.CoreModules.Framework.UserManagement
+namespace MutSea.Region.CoreModules.Framework.UserManagement
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "UserManagementModule")]
     public class UserManagementModule : ISharedRegionModule, IUserManagement, IPeople

--- a/OpenSim/Services/AssetService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/AssetService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.AssetService")]
+[assembly: AssemblyTitle("MutSea.Services.AssetService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/AuthenticationService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/AuthenticationService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.AuthenticationService")]
+[assembly: AssemblyTitle("MutSea.Services.AuthenticationService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/AuthorizationService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/AuthorizationService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.AuthorizationService")]
+[assembly: AssemblyTitle("MutSea.Services.AuthorizationService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/AvatarService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/AvatarService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.AvatarService")]
+[assembly: AssemblyTitle("MutSea.Services.AvatarService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/Base/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/Base/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.Base")]
+[assembly: AssemblyTitle("MutSea.Services.Base")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/Connectors/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/Connectors/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.Connectors")]
+[assembly: AssemblyTitle("MutSea.Services.Connectors")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/FreeswitchService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/FreeswitchService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.FreeswitchService")]
+[assembly: AssemblyTitle("MutSea.Services.FreeswitchService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/Friends/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/Friends/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.FriendsService")]
+[assembly: AssemblyTitle("MutSea.Services.FriendsService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/GridService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/GridService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.GridService")]
+[assembly: AssemblyTitle("MutSea.Services.GridService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/HypergridService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/HypergridService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.HypergridService")]
+[assembly: AssemblyTitle("MutSea.Services.HypergridService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/Interfaces/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/Interfaces/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.Interfaces")]
+[assembly: AssemblyTitle("MutSea.Services.Interfaces")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/InventoryService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/InventoryService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.InventoryService")]
+[assembly: AssemblyTitle("MutSea.Services.InventoryService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/LLLoginService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/LLLoginService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.LLLoginService")]
+[assembly: AssemblyTitle("MutSea.Services.LLLoginService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/MapImageService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/MapImageService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.MapImageService")]
+[assembly: AssemblyTitle("MutSea.Services.MapImageService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/PresenceService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/PresenceService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.PresenceService")]
+[assembly: AssemblyTitle("MutSea.Services.PresenceService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Services/UserAccountService/Properties/AssemblyInfo.cs
+++ b/OpenSim/Services/UserAccountService/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Services.UserAccountService")]
+[assembly: AssemblyTitle("MutSea.Services.UserAccountService")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]

--- a/OpenSim/Tools/Configger/Properties/AssemblyInfo.cs
+++ b/OpenSim/Tools/Configger/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("OpenSim.Tools.Configger")]
+[assembly: AssemblyTitle("MutSea.Tools.Configger")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Finalverse Inc.")]


### PR DESCRIPTION
## Summary
- switch OpenSim namespaces under `Region/CoreModules/Framework` to `MutSea`
- update AssemblyInfo titles in Properties directories

## Testing
- `nant test` *(fails: `nant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8462e7f88332bc3c1a1ac1cd6479