### PR TITLE
Replace namespaces in agent modules

### DIFF
--- a/OpenSim/Region/CoreModules/Agent/AssetTransaction/AgentAssetsTransactions.cs
+++ b/OpenSim/Region/CoreModules/Agent/AssetTransaction/AgentAssetsTransactions.cs
@@ -35,7 +35,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using OpenSim.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.CoreModules.Agent.AssetTransaction
+namespace MutSea.Region.CoreModules.Agent.AssetTransaction
 {
     /// <summary>
     /// Manage asset transactions for a single agent.

--- a/OpenSim/Region/CoreModules/Agent/AssetTransaction/AssetTransactionModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/AssetTransaction/AssetTransactionModule.cs
@@ -36,7 +36,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Agent.AssetTransaction
+namespace MutSea.Region.CoreModules.Agent.AssetTransaction
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "AssetTransactionModule")]
     public class AssetTransactionModule : INonSharedRegionModule,

--- a/OpenSim/Region/CoreModules/Agent/AssetTransaction/AssetXferUploader.cs
+++ b/OpenSim/Region/CoreModules/Agent/AssetTransaction/AssetXferUploader.cs
@@ -37,7 +37,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.CoreModules.Agent.AssetTransaction
+namespace MutSea.Region.CoreModules.Agent.AssetTransaction
 {
     public class AssetXferUploader
     {

--- a/OpenSim/Region/CoreModules/Agent/IPBan/IPBanModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/IPBan/IPBanModule.cs
@@ -35,7 +35,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Agent.IPBan
+namespace MutSea.Region.CoreModules.Agent.IPBan
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "IPBanModule")]
     public class IPBanModule : ISharedRegionModule

--- a/OpenSim/Region/CoreModules/Agent/IPBan/SceneBanner.cs
+++ b/OpenSim/Region/CoreModules/Agent/IPBan/SceneBanner.cs
@@ -30,7 +30,7 @@ using System.Net;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.CoreModules.Agent.IPBan
+namespace MutSea.Region.CoreModules.Agent.IPBan
 {
     internal class SceneBanner
     {

--- a/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderModule.cs
@@ -43,7 +43,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.CoreModules.Agent.TextureSender
+namespace MutSea.Region.CoreModules.Agent.TextureSender
 {
     public delegate void J2KDecodeDelegate(UUID assetID);
 

--- a/OpenSim/Region/CoreModules/Agent/Xfer/XferModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/Xfer/XferModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Region.Framework.Scenes;
 
 using Mono.Addins;
 
-namespace OpenSim.Region.CoreModules.Agent.Xfer
+namespace MutSea.Region.CoreModules.Agent.Xfer
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "XferModule")]
     public class XferModule : INonSharedRegionModule, IXfer


### PR DESCRIPTION
## Summary
- migrate agent module namespaces to `MutSea`

## Testing
- `make test` *(fails: `dotnet: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a845b37588332aa71537cf14a9605