### PR TITLE
Adjust namespaces to MutSea

### DIFF
--- a/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/IRCStackModule.cs
+++ b/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/IRCStackModule.cs
@@ -36,7 +36,7 @@ using OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server;
 
 using Mono.Addins;
 
-namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView
+namespace MutSea.Region.OptionalModules.Agent.InternetRelayClientView
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "IRCStackModule")]
     public class IRCStackModule : INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/Server/IRCClientView.cs
+++ b/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/Server/IRCClientView.cs
@@ -41,7 +41,7 @@ using OpenSim.Framework.Client;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server
+namespace MutSea.Region.OptionalModules.Agent.InternetRelayClientView.Server
 {
     public delegate void OnIRCClientReadyDelegate(IRCClientView cv);
 

--- a/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/Server/IRCServer.cs
+++ b/OpenSim/Region/OptionalModules/Agent/InternetRelayClientView/Server/IRCServer.cs
@@ -37,7 +37,7 @@ using OpenSim.Framework;
 using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Agent.InternetRelayClientView.Server
+namespace MutSea.Region.OptionalModules.Agent.InternetRelayClientView.Server
 {
     public delegate void OnNewIRCUserDelegate(IRCClientView user);
 

--- a/OpenSim/Region/OptionalModules/Agent/TextureSender/J2KDecoderCommandModule.cs
+++ b/OpenSim/Region/OptionalModules/Agent/TextureSender/J2KDecoderCommandModule.cs
@@ -40,7 +40,7 @@ using OpenSim.Framework.Console;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Agent.TextureSender
+namespace MutSea.Region.OptionalModules.Agent.TextureSender
 {
     /// <summary>
     /// Commands for the J2KDecoder module.  For debugging purposes.

--- a/OpenSim/Region/OptionalModules/Agent/UDP/Linden/LindenUDPInfoModule.cs
+++ b/OpenSim/Region/OptionalModules/Agent/UDP/Linden/LindenUDPInfoModule.cs
@@ -40,7 +40,7 @@ using OpenSim.Region.ClientStack.LindenUDP;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.UDP.Linden
+namespace MutSea.Region.OptionalModules.UDP.Linden
 {
     /// <summary>
     /// A module that just holds commands for inspecting the current state of the Linden UDP stack.

--- a/OpenSim/Region/OptionalModules/Asset/AssetInfoModule.cs
+++ b/OpenSim/Region/OptionalModules/Asset/AssetInfoModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Framework.Console;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Asset
+namespace MutSea.Region.OptionalModules.Asset
 {
     /// <summary>
     /// A module that just holds commands for inspecting assets.

--- a/OpenSim/Region/OptionalModules/Avatar/Animations/AnimationsCommandModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Animations/AnimationsCommandModule.cs
@@ -44,7 +44,7 @@ using OpenSim.Region.Framework.Scenes.Animation;
 using OpenSim.Services.Interfaces;
 using AnimationSet = OpenSim.Region.Framework.Scenes.Animation.AnimationSet;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Animations
+namespace MutSea.Region.OptionalModules.Avatar.Animations
 {
     /// <summary>
     /// A module that just holds commands for inspecting avatar animations.

--- a/OpenSim/Region/OptionalModules/Avatar/Appearance/AppearanceInfoModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Appearance/AppearanceInfoModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Region.ClientStack.LindenUDP;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Appearance
+namespace MutSea.Region.OptionalModules.Avatar.Appearance
 {
     /// <summary>
     /// A module that just holds commands for inspecting avatar appearance.

--- a/OpenSim/Region/OptionalModules/Avatar/Chat/ChannelState.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Chat/ChannelState.cs
@@ -35,7 +35,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Chat
+namespace MutSea.Region.OptionalModules.Avatar.Chat
 {
 
     // An instance of this class exists for each unique combination of

--- a/OpenSim/Region/OptionalModules/Avatar/Chat/IRCBridgeModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Chat/IRCBridgeModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Chat
+namespace MutSea.Region.OptionalModules.Avatar.Chat
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "IRCBridgeModule")]
     public class IRCBridgeModule : INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/Avatar/Chat/IRCConnector.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Chat/IRCConnector.cs
@@ -41,7 +41,7 @@ using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Chat
+namespace MutSea.Region.OptionalModules.Avatar.Chat
 {
     public class IRCConnector
     {

--- a/OpenSim/Region/OptionalModules/Avatar/Chat/RegionState.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Chat/RegionState.cs
@@ -35,7 +35,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Chat
+namespace MutSea.Region.OptionalModules.Avatar.Chat
 {
     //    An instance of this class exists for every active region
 

--- a/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Concierge/ConciergeModule.cs
@@ -46,7 +46,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.CoreModules.Avatar.Chat;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Concierge
+namespace MutSea.Region.OptionalModules.Avatar.Concierge
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "ConciergeModule")]
     public class ConciergeModule : ChatModule, ISharedRegionModule

--- a/OpenSim/Region/OptionalModules/Avatar/Friends/FriendsCommandsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Friends/FriendsCommandsModule.cs
@@ -45,7 +45,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using FriendInfo = OpenSim.Services.Interfaces.FriendInfo;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Friends
+namespace MutSea.Region.OptionalModules.Avatar.Friends
 {
     /// <summary>
     /// A module that just holds commands for inspecting avatar appearance.

--- a/OpenSim/Region/OptionalModules/Avatar/SitStand/SitStandCommandsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/SitStand/SitStandCommandsModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Framework.Console;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.SitStand
+namespace MutSea.Region.OptionalModules.Avatar.SitStand
 {
     /// <summary>
     /// A module that just holds commands for changing avatar sitting and standing states.

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/FreeSwitchVoice/FreeSwitchVoiceModule.cs
@@ -55,7 +55,7 @@ using OpenSim.Server.Base;
 using OpenSim.Services.Interfaces;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
+namespace MutSea.Region.OptionalModules.Avatar.Voice.FreeSwitchVoice
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "FreeSwitchVoiceModule")]
     public class FreeSwitchVoiceModule : ISharedRegionModule, IVoiceModule

--- a/OpenSim/Region/OptionalModules/Avatar/Voice/VivoxVoice/VivoxVoiceModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/Voice/VivoxVoice/VivoxVoiceModule.cs
@@ -45,7 +45,7 @@ using OpenSim.Region.Framework.Scenes;
 using Caps = OpenSim.Framework.Capabilities.Caps;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Voice.VivoxVoice
+namespace MutSea.Region.OptionalModules.Avatar.Voice.VivoxVoice
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "VivoxVoiceModule")]
     public class VivoxVoiceModule : ISharedRegionModule

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/GroupsMessagingModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/GroupsMessagingModule.cs
@@ -40,7 +40,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using PresenceInfo = OpenSim.Services.Interfaces.PresenceInfo;
 
-namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
+namespace MutSea.Region.OptionalModules.Avatar.XmlRpcGroups
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "GroupsMessagingModule")]
     public class GroupsMessagingModule : ISharedRegionModule, IGroupsMessagingModule

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/GroupsModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/GroupsModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Services.Interfaces;
 using System.Text;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
+namespace MutSea.Region.OptionalModules.Avatar.XmlRpcGroups
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "GroupsModule")]
     public class GroupsModule : ISharedRegionModule, IGroupsModule

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/IGroupsServicesConnector.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/IGroupsServicesConnector.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using OpenMetaverse;
 using OpenSim.Framework;
 
-namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
+namespace MutSea.Region.OptionalModules.Avatar.XmlRpcGroups
 {
     public interface IGroupsServicesConnector
     {

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/Tests/GroupsModuleTests.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/Tests/GroupsModuleTests.cs
@@ -46,7 +46,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups.Tests
+namespace MutSea.Region.OptionalModules.Avatar.XmlRpcGroups.Tests
 {
     /// <summary>
     /// Basic groups module tests

--- a/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupsServicesConnectorModule.cs
+++ b/OpenSim/Region/OptionalModules/Avatar/XmlRpcGroups/XmlRpcGroupsServicesConnectorModule.cs
@@ -44,7 +44,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups
+namespace MutSea.Region.OptionalModules.Avatar.XmlRpcGroups
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "XmlRpcGroupsServicesConnectorModule")]
     public class XmlRpcGroupsServicesConnectorModule : ISharedRegionModule, IGroupsServicesConnector

--- a/OpenSim/Region/OptionalModules/Example/BareBonesNonShared/BareBonesNonSharedModule.cs
+++ b/OpenSim/Region/OptionalModules/Example/BareBonesNonShared/BareBonesNonSharedModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Region.Framework.Scenes;
 //[assembly: Addin("MyModule", "1.0")]
 //[assembly: AddinDependency("OpenSim", "0.8.1")]
 
-namespace OpenSim.Region.OptionalModules.Example.BareBonesNonShared
+namespace MutSea.Region.OptionalModules.Example.BareBonesNonShared
 {
     /// <summary>
     /// Simplest possible example of a non-shared region module.

--- a/OpenSim/Region/OptionalModules/Example/BareBonesShared/BareBonesSharedModule.cs
+++ b/OpenSim/Region/OptionalModules/Example/BareBonesShared/BareBonesSharedModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Region.Framework.Scenes;
 //[assembly: Addin("MyModule", "1.0")]
 //[assembly: AddinDependency("OpenSim", "0.8.1")]
 
-namespace OpenSim.Region.OptionalModules.Example.BareBonesShared
+namespace MutSea.Region.OptionalModules.Example.BareBonesShared
 {
     /// <summary>
     /// Simplest possible example of a shared region module.

--- a/OpenSim/Region/OptionalModules/Example/WebSocketEchoTest/WebSocketEchoModule.cs
+++ b/OpenSim/Region/OptionalModules/Example/WebSocketEchoTest/WebSocketEchoModule.cs
@@ -38,7 +38,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework.Servers.HttpServer;
 
 
-namespace OpenSim.Region.OptionalModules.WebSocketEchoModule
+namespace MutSea.Region.OptionalModules.WebSocketEchoModule
 {
 
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "WebSocketEchoModule")]

--- a/OpenSim/Region/OptionalModules/Framework/Monitoring/EtcdMonitoringModule.cs
+++ b/OpenSim/Region/OptionalModules/Framework/Monitoring/EtcdMonitoringModule.cs
@@ -42,7 +42,7 @@ using netcd.Serialization;
 using netcd.Advanced;
 using netcd.Advanced.Requests;
 
-namespace OpenSim.Region.OptionalModules.Framework.Monitoring
+namespace MutSea.Region.OptionalModules.Framework.Monitoring
 {
     /// <summary>
     /// Allows to store monitoring data in etcd, a high availability

--- a/OpenSim/Region/OptionalModules/Materials/MaterialsModule.cs
+++ b/OpenSim/Region/OptionalModules/Materials/MaterialsModule.cs
@@ -47,7 +47,7 @@ using OpenSim.Region.Framework.Scenes;
 
 using Ionic.Zlib;
 
-namespace OpenSim.Region.OptionalModules.Materials
+namespace MutSea.Region.OptionalModules.Materials
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "MaterialsModule")]
     public class MaterialsModule : INonSharedRegionModule, IMaterialsModule

--- a/OpenSim/Region/OptionalModules/PhysicsParameters/PhysicsParameters.cs
+++ b/OpenSim/Region/OptionalModules/PhysicsParameters/PhysicsParameters.cs
@@ -38,7 +38,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.PhysicsModules.SharedBase;
 
-namespace OpenSim.Region.OptionalModules.PhysicsParameters
+namespace MutSea.Region.OptionalModules.PhysicsParameters
 {
     /// <summary>
     /// </summary>

--- a/OpenSim/Region/OptionalModules/PrimLimitsModule/PrimLimitsModule.cs
+++ b/OpenSim/Region/OptionalModules/PrimLimitsModule/PrimLimitsModule.cs
@@ -37,7 +37,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules
+namespace MutSea.Region.OptionalModules
 {
     /// <summary>
     /// Enables Prim limits for parcel.

--- a/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStore.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStore.cs
@@ -42,7 +42,7 @@ using OpenSim.Region.Framework.Scenes;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
+namespace MutSea.Region.OptionalModules.Scripting.JsonStore
 {
     public class JsonStore
     {

--- a/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreCommands.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreCommands.cs
@@ -42,7 +42,7 @@ using OpenSim.Region.Framework.Scenes;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
+namespace MutSea.Region.OptionalModules.Scripting.JsonStore
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "JsonStoreCommandsModule")]
 

--- a/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreModule.cs
@@ -42,7 +42,7 @@ using OpenSim.Region.Framework.Scenes;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
+namespace MutSea.Region.OptionalModules.Scripting.JsonStore
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "JsonStoreModule")]
 

--- a/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreScriptModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/JsonStore/JsonStoreScriptModule.cs
@@ -44,7 +44,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.OptionalModules.Scripting.JsonStore
+namespace MutSea.Region.OptionalModules.Scripting.JsonStore
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "JsonStoreScriptModule")]
 

--- a/OpenSim/Region/OptionalModules/Scripting/JsonStore/Tests/JsonStoreScriptModuleTests.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/JsonStore/Tests/JsonStoreScriptModuleTests.cs
@@ -41,7 +41,7 @@ using OpenSim.Region.ScriptEngine.Shared.Api;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.OptionalModules.Scripting.JsonStore.Tests
+namespace MutSea.Region.OptionalModules.Scripting.JsonStore.Tests
 {
     /// <summary>
     /// Tests for inventory functions in LSL

--- a/OpenSim/Region/OptionalModules/Scripting/RegionReadyModule/RegionReadyModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/RegionReadyModule/RegionReadyModule.cs
@@ -44,7 +44,7 @@ using OpenSim.Services.Interfaces;
 using System.Net.Http;
 using System.Threading;
 
-namespace OpenSim.Region.OptionalModules.Scripting.RegionReady
+namespace MutSea.Region.OptionalModules.Scripting.RegionReady
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "RegionReadyModule")]
     public class RegionReadyModule : IRegionReadyModule, INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcGridRouterModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcGridRouterModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Framework.Client;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Scripting.XmlRpcGridRouterModule
+namespace MutSea.Region.OptionalModules.Scripting.XmlRpcGridRouterModule
 {
     public class XmlRpcInfo
     {

--- a/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcRouterModule.cs
+++ b/OpenSim/Region/OptionalModules/Scripting/XmlRpcRouterModule/XmlRpcRouterModule.cs
@@ -38,7 +38,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
 
-namespace OpenSim.Region.OptionalModules.Scripting.XmlRpcRouterModule
+namespace MutSea.Region.OptionalModules.Scripting.XmlRpcRouterModule
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "XmlRpcRouter")]
     public class XmlRpcRouter : INonSharedRegionModule, IXmlRpcRouter

--- a/OpenSim/Region/OptionalModules/ViewerSupport/CameraOnlyModeModule.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/CameraOnlyModeModule.cs
@@ -49,7 +49,7 @@ using Mono.Addins;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 using TeleportFlags = OpenSim.Framework.Constants.TeleportFlags;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "CameraOnlyMode")]
     public class CameraOnlyModeModule : INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/ViewerSupport/DynamicFloaterModule.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/DynamicFloaterModule.cs
@@ -46,7 +46,7 @@ using Mono.Addins;
 using Caps = OpenSim.Framework.Capabilities.Caps;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "DynamicFloater")]
     public class DynamicFloaterModule : INonSharedRegionModule, IDynamicFloaterModule

--- a/OpenSim/Region/OptionalModules/ViewerSupport/DynamicMenuModule.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/DynamicMenuModule.cs
@@ -42,7 +42,7 @@ using Mono.Addins;
 using Caps = OpenSim.Framework.Capabilities.Caps;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "DynamicMenu")]
     public class DynamicMenuModule : INonSharedRegionModule, IDynamicMenuModule

--- a/OpenSim/Region/OptionalModules/ViewerSupport/GodNamesModule.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/GodNamesModule.cs
@@ -37,7 +37,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "GodNamesModule")]
     public class GodNamesModule : ISharedRegionModule

--- a/OpenSim/Region/OptionalModules/ViewerSupport/SimulatorFeaturesHelper.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/SimulatorFeaturesHelper.cs
@@ -47,7 +47,7 @@ using log4net;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 using TeleportFlags = OpenSim.Framework.Constants.TeleportFlags;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     public class SimulatorFeaturesHelper
     {

--- a/OpenSim/Region/OptionalModules/ViewerSupport/SpecialUIModule.cs
+++ b/OpenSim/Region/OptionalModules/ViewerSupport/SpecialUIModule.cs
@@ -48,7 +48,7 @@ using Mono.Addins;
 using OSDMap = OpenMetaverse.StructuredData.OSDMap;
 using TeleportFlags = OpenSim.Framework.Constants.TeleportFlags;
 
-namespace OpenSim.Region.OptionalModules.ViewerSupport
+namespace MutSea.Region.OptionalModules.ViewerSupport
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "SpecialUI")]
     public class SpecialUIModule : INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/World/AutoBackup/AutoBackupModule.cs
+++ b/OpenSim/Region/OptionalModules/World/AutoBackup/AutoBackupModule.cs
@@ -39,7 +39,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.World.AutoBackup
+namespace MutSea.Region.OptionalModules.World.AutoBackup
 {
     /// <summary>
     /// Choose between ways of naming the backup files that are generated.

--- a/OpenSim/Region/OptionalModules/World/AutoBackup/AutoBackupModuleState.cs
+++ b/OpenSim/Region/OptionalModules/World/AutoBackup/AutoBackupModuleState.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 
 
-namespace OpenSim.Region.OptionalModules.World.AutoBackup
+namespace MutSea.Region.OptionalModules.World.AutoBackup
 {
     /// <summary>AutoBackupModuleState: Auto-Backup state for one region (scene).
     /// If you use this class in any way outside of AutoBackupModule, you should treat the class as opaque.

--- a/OpenSim/Region/OptionalModules/World/MoneyModule/SampleMoneyModule.cs
+++ b/OpenSim/Region/OptionalModules/World/MoneyModule/SampleMoneyModule.cs
@@ -43,7 +43,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.OptionalModules.World.MoneyModule
+namespace MutSea.Region.OptionalModules.World.MoneyModule
 {
     /// <summary>
     /// This is only the functionality required to make the functionality associated with money work

--- a/OpenSim/Region/OptionalModules/World/NPC/NPCAvatar.cs
+++ b/OpenSim/Region/OptionalModules/World/NPC/NPCAvatar.cs
@@ -38,7 +38,7 @@ using log4net;
 using System.Reflection;
 using System.Xml;
 
-namespace OpenSim.Region.OptionalModules.World.NPC
+namespace MutSea.Region.OptionalModules.World.NPC
 {
     public class NPCAvatar : IClientAPI, INPC
     {

--- a/OpenSim/Region/OptionalModules/World/NPC/NPCModule.cs
+++ b/OpenSim/Region/OptionalModules/World/NPC/NPCModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Framework;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.OptionalModules.World.NPC
+namespace MutSea.Region.OptionalModules.World.NPC
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "NPCModule")]
     public class NPCModule : INPCModule, ISharedRegionModule

--- a/OpenSim/Region/OptionalModules/World/NPC/Tests/NPCModuleTests.cs
+++ b/OpenSim/Region/OptionalModules/World/NPC/Tests/NPCModuleTests.cs
@@ -43,7 +43,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.AvatarService;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.OptionalModules.World.NPC.Tests
+namespace MutSea.Region.OptionalModules.World.NPC.Tests
 {
     [TestFixture]
     public class NPCModuleTests : OpenSimTestCase

--- a/OpenSim/Region/OptionalModules/World/SceneCommands/SceneCommandsModule.cs
+++ b/OpenSim/Region/OptionalModules/World/SceneCommands/SceneCommandsModule.cs
@@ -41,7 +41,7 @@ using OpenSim.Framework.Monitoring;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.OptionalModules.Avatar.Attachments
+namespace MutSea.Region.OptionalModules.Avatar.Attachments
 {
     /// <summary>
     /// A module that just holds commands for inspecting avatar appearance.

--- a/OpenSim/Region/OptionalModules/World/TreePopulator/TreePopulatorModule.cs
+++ b/OpenSim/Region/OptionalModules/World/TreePopulator/TreePopulatorModule.cs
@@ -45,7 +45,7 @@ using OpenSim.Region.Framework.Scenes;
 
 using Timer= System.Timers.Timer;
 
-namespace OpenSim.Region.OptionalModules.World.TreePopulator
+namespace MutSea.Region.OptionalModules.World.TreePopulator
 {
     /// <summary>
     /// Version 2.02 - Still hacky

--- a/OpenSim/Region/OptionalModules/World/WorldView/WorldViewModule.cs
+++ b/OpenSim/Region/OptionalModules/World/WorldView/WorldViewModule.cs
@@ -44,7 +44,7 @@ using OpenSim.Server.Base;
 using OpenSim.Framework.Servers.HttpServer;
 using OpenSim.Services.Interfaces;
 
-namespace OpenSim.Region.OptionalModules.World.WorldView
+namespace MutSea.Region.OptionalModules.World.WorldView
 {
     [Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "WorldViewModule")]
     public class WorldViewModule : INonSharedRegionModule

--- a/OpenSim/Region/OptionalModules/World/WorldView/WorldViewRequestHandler.cs
+++ b/OpenSim/Region/OptionalModules/World/WorldView/WorldViewRequestHandler.cs
@@ -40,7 +40,7 @@ using OpenSim.Region.Framework.Interfaces;
 using OpenMetaverse;
 using log4net;
 
-namespace OpenSim.Region.OptionalModules.World.WorldView
+namespace MutSea.Region.OptionalModules.World.WorldView
 {
     public class WorldViewRequestHandler : BaseStreamHandler
     {


### PR DESCRIPTION
## Summary
- use `MutSea` root namespace for optional modules

## Testing
- `nant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8a3ffc3c8332af20a07d3b2b84e2