### PR TITLE
Adjust ScriptEngine namespaces

### DIFF
--- a/OpenSim/Region/ScriptEngine/Interfaces/ICompiler.cs
+++ b/OpenSim/Region/ScriptEngine/Interfaces/ICompiler.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using OpenMetaverse;
 using Nini.Config;
 
-namespace OpenSim.Region.ScriptEngine.Interfaces
+namespace MutSea.Region.ScriptEngine.Interfaces
 {
     public interface ICompiler
     {

--- a/OpenSim/Region/ScriptEngine/Interfaces/IScript.cs
+++ b/OpenSim/Region/ScriptEngine/Interfaces/IScript.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using OpenSim.Region.ScriptEngine.Interfaces;
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public interface IScript
     {

--- a/OpenSim/Region/ScriptEngine/Interfaces/IScriptApi.cs
+++ b/OpenSim/Region/ScriptEngine/Interfaces/IScriptApi.cs
@@ -32,7 +32,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Interfaces
+namespace MutSea.Region.ScriptEngine.Interfaces
 {
     public interface IScriptApi
     {

--- a/OpenSim/Region/ScriptEngine/Interfaces/IScriptEngine.cs
+++ b/OpenSim/Region/ScriptEngine/Interfaces/IScriptEngine.cs
@@ -37,7 +37,7 @@ using log4net;
 using Nini.Config;
 using OpenMetaverse;
 
-namespace OpenSim.Region.ScriptEngine.Interfaces
+namespace MutSea.Region.ScriptEngine.Interfaces
 {
     /// <summary>
     /// An interface for a script API module to communicate with

--- a/OpenSim/Region/ScriptEngine/Interfaces/IScriptInstance.cs
+++ b/OpenSim/Region/ScriptEngine/Interfaces/IScriptInstance.cs
@@ -37,7 +37,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Interfaces;
 
-namespace OpenSim.Region.ScriptEngine.Interfaces
+namespace MutSea.Region.ScriptEngine.Interfaces
 {
     public enum StateSource
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/ApiManager.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/ApiManager.cs
@@ -32,7 +32,7 @@ using System.Reflection;
 using log4net;
 using OpenSim.Region.ScriptEngine.Interfaces;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     public class ApiManager
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/AsyncCommandManager.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/AsyncCommandManager.cs
@@ -40,7 +40,7 @@ using ScriptTimer=OpenSim.Region.ScriptEngine.Shared.Api.Plugins.ScriptTimer;
 using System.Reflection;
 using log4net;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     /// <summary>
     /// Handles LSL commands that takes long time and returns an event, for example timers, HTTP requests, etc.

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LSL_Api.cs
@@ -75,7 +75,7 @@ using System.Runtime.CompilerServices;
 
 #pragma warning disable IDE1006
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     /// <summary>
     /// Contains all LSL ll-functions. This class will be in Default AppDomain.

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LS_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/LS_Api.cs
@@ -51,7 +51,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     [Serializable]
     public class LS_Api : ILS_Api, IScriptApi

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/MOD_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/MOD_Api.cs
@@ -51,7 +51,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     [Serializable]
     public class MOD_Api : IMOD_Api, IScriptApi

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/OSSL_Api.cs
@@ -60,7 +60,7 @@ using TPFlags = OpenSim.Framework.Constants.TeleportFlags;
 
 #pragma warning disable IDE1006
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api
+namespace MutSea.Region.ScriptEngine.Shared.Api
 {
     //////////////////////////////////////////////////////////////
     //

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/Dataserver.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/Dataserver.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using OpenMetaverse;
 using OpenSim.Framework;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class Dataserver
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/HttpRequest.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/HttpRequest.cs
@@ -32,7 +32,7 @@ using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared.Api;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class HttpRequest
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/Listener.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/Listener.cs
@@ -34,7 +34,7 @@ using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class Listener
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/ScriptTimer.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/ScriptTimer.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using OpenMetaverse;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class ScriptTimer
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/SensorRepeat.cs
@@ -34,7 +34,7 @@ using OpenSim.Framework;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class SensorRepeat
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/XmlRequest.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Implementation/Plugins/XmlRequest.cs
@@ -32,7 +32,7 @@ using OpenSim.Region.ScriptEngine.Interfaces;
 using OpenSim.Region.ScriptEngine.Shared;
 using OpenSim.Region.ScriptEngine.Shared.Api;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Plugins
+namespace MutSea.Region.ScriptEngine.Shared.Api.Plugins
 {
     public class XmlRequest
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILSL_Api.cs
@@ -37,7 +37,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
 #pragma warning disable IDE1006
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
+namespace MutSea.Region.ScriptEngine.Shared.Api.Interfaces
 {
     public interface ILSL_Api
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILS_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/ILS_Api.cs
@@ -36,7 +36,7 @@ using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
+namespace MutSea.Region.ScriptEngine.Shared.Api.Interfaces
 {
     public interface ILS_Api
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IMOD_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IMOD_Api.cs
@@ -36,7 +36,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
+namespace MutSea.Region.ScriptEngine.Shared.Api.Interfaces
 {
     public interface IMOD_Api
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Interface/IOSSL_Api.cs
@@ -38,7 +38,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_Key = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 
 
-namespace OpenSim.Region.ScriptEngine.Shared.Api.Interfaces
+namespace MutSea.Region.ScriptEngine.Shared.Api.Interfaces
 {
     /// <summary>
     /// To permit region owners to enable the extended scripting functionality

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Constants.cs
@@ -30,7 +30,7 @@ using vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 using rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSLInteger = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LSL_Stub.cs
@@ -41,7 +41,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
 #pragma warning disable IDE1006
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LS_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/LS_Stub.cs
@@ -43,7 +43,7 @@ using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Float = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLFloat;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/MOD_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/MOD_Stub.cs
@@ -47,7 +47,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/OSSL_Stub.cs
@@ -42,7 +42,7 @@ using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 
 #pragma warning disable IDE1006
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/ScriptBase.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Api/Runtime/ScriptBase.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 using System.Diagnostics; //for [DebuggerNonUserCode]
 using OpenSim.Region.ScriptEngine.Interfaces;
 
-namespace OpenSim.Region.ScriptEngine.Shared.ScriptBase
+namespace MutSea.Region.ScriptEngine.Shared.ScriptBase
 {
     public partial class ScriptBaseClass : IScript
     {

--- a/OpenSim/Region/ScriptEngine/Shared/Helpers.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Helpers.cs
@@ -38,7 +38,7 @@ using OpenSim.Region.Framework.Scenes;
 using OpenSim.Services.Interfaces;
 using OpenSim.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.ScriptEngine.Shared
+namespace MutSea.Region.ScriptEngine.Shared
 {
     [Serializable]
     public class EventAbortException : Exception

--- a/OpenSim/Region/ScriptEngine/Shared/LSL_Types.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/LSL_Types.cs
@@ -39,7 +39,7 @@ using OMV_Vector3d = OpenMetaverse.Vector3d;
 using OMV_Quaternion = OpenMetaverse.Quaternion;
 using System.Runtime.InteropServices;
 
-namespace OpenSim.Region.ScriptEngine.Shared
+namespace MutSea.Region.ScriptEngine.Shared
 {
     public partial class LSL_Types
     {

--- a/OpenSim/Region/ScriptEngine/Shared/ScriptException.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/ScriptException.cs
@@ -28,7 +28,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace OpenSim.Region.ScriptEngine.Shared
+namespace MutSea.Region.ScriptEngine.Shared
 {
     [Serializable]
     public class ScriptException : Exception

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiAvatarTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiAvatarTests.cs
@@ -47,7 +47,7 @@ using OpenSim.Tests.Common;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 using LSL_List = OpenSim.Region.ScriptEngine.Shared.LSL_Types.list;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests relating directly to avatars

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiHttpTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiHttpTests.cs
@@ -46,7 +46,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for HTTP related functions in LSL

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiInventoryTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiInventoryTests.cs
@@ -46,7 +46,7 @@ using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 using PermissionMask = OpenSim.Framework.PermissionMask;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for inventory functions in LSL

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiLinkingTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiLinkingTests.cs
@@ -45,7 +45,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for linking functions in LSL

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiListTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiListTests.cs
@@ -42,7 +42,7 @@ using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 using LSL_List = OpenSim.Region.ScriptEngine.Shared.LSL_Types.list;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_ApiListTests : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiNotecardTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiNotecardTests.cs
@@ -19,7 +19,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for notecard related functions in LSL

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiObjectTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiObjectTests.cs
@@ -47,7 +47,7 @@ using OpenSim.Tests.Common;
 using LSL_Integer = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLInteger;
 using LSL_List = OpenSim.Region.ScriptEngine.Shared.LSL_Types.list;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_ApiObjectTests : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiTest.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiTest.cs
@@ -37,7 +37,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenMetaverse;
 using System;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for LSL_Api

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiUserTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_ApiUserTests.cs
@@ -38,7 +38,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_ApiUserTests : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLFloat.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLFloat.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 using OpenSim.Tests.Common;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_TypesTestLSLFloat : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLInteger.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLInteger.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 using OpenSim.Tests.Common;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_TypesTestLSLInteger : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLString.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestLSLString.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 using OpenSim.Tests.Common;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     [TestFixture]
     public class LSL_TypesTestLSLString : OpenSimTestCase

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestList.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestList.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 using OpenSim.Tests.Common;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests the LSL_Types.list class.

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestVector3.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/LSL_TypesTestVector3.cs
@@ -30,7 +30,7 @@ using NUnit.Framework;
 using OpenSim.Tests.Common;
 using OpenSim.Region.ScriptEngine.Shared;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for Vector3

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiAppearanceTest.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiAppearanceTest.cs
@@ -44,7 +44,7 @@ using OpenSim.Region.ScriptEngine.Shared.Api;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for OSSL_Api

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiAttachmentTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiAttachmentTests.cs
@@ -44,7 +44,7 @@ using OpenSim.Region.ScriptEngine.Shared.Api;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for OSSL attachment functions

--- a/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiNpcTests.cs
+++ b/OpenSim/Region/ScriptEngine/Shared/Tests/OSSL_ApiNpcTests.cs
@@ -46,7 +46,7 @@ using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Services.Interfaces;
 using OpenSim.Tests.Common;
 
-namespace OpenSim.Region.ScriptEngine.Shared.Tests
+namespace MutSea.Region.ScriptEngine.Shared.Tests
 {
     /// <summary>
     /// Tests for OSSL NPC API

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRDelegateCommon.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRDelegateCommon.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public class DelegateCommon

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRIEventHandlers.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRIEventHandlers.cs
@@ -33,7 +33,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public interface IEventHandlers
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRInternalFuncDict.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRInternalFuncDict.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public class InternalFuncDict: VarDict

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptBinOpStr.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptBinOpStr.cs
@@ -41,7 +41,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     /**

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCodeGen.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCodeGen.cs
@@ -48,7 +48,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
  * The single script token contains a tokenized and textured version of the whole script file.
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public interface IScriptCodeGen
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCollector.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCollector.cs
@@ -41,7 +41,7 @@ using System.Text;
  *        Second is it removes unnecessary back-to-back stloc/ldloc's.
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /**
      * @brief This is a list that keeps track of types pushed on the evaluation stack.

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCompValu.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCompValu.cs
@@ -78,7 +78,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
  *            cv.CallPost()    - calls the function/method
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     /**

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCompile.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptCompile.cs
@@ -32,7 +32,7 @@
 using System;
 using System.IO;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class XMRInstance
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptConsts.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptConsts.cs
@@ -37,7 +37,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public class ScriptConst

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptEventCode.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptEventCode.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     /**

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptInlines.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptInlines.cs
@@ -42,7 +42,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 /**
  * @brief Generate code for the backend API calls.
  */
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public abstract class TokenDeclInline: TokenDeclVar
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptMyILGen.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptMyILGen.cs
@@ -29,7 +29,7 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public interface ScriptMyILGen
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptObjCode.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptObjCode.cs
@@ -32,7 +32,7 @@ using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public delegate void ScriptEventHandler(XMRInstAbstract instance);
 

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptObjWriter.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptObjWriter.cs
@@ -46,7 +46,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
  *        It writes the object code to a file and can then make real ILGenerator calls
  *        based on the file's contents.
  */
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public enum ScriptObjWriterCode: byte
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptReduce.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptReduce.cs
@@ -56,7 +56,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public class ScriptReduce
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptTokenize.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptTokenize.cs
@@ -57,7 +57,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public delegate void TokenErrorMessage(Token token, string message);

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptTypeCast.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptTypeCast.cs
@@ -44,7 +44,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
  * @brief Generate script object code to perform type casting
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public class TypeCast

--- a/OpenSim/Region/ScriptEngine/YEngine/MMRScriptVarDict.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/MMRScriptVarDict.cs
@@ -33,7 +33,7 @@ using System.Collections.Generic;
  * @brief Collection of variable/function/method definitions
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public class VarDict: IEnumerable
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRArray.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRArray.cs
@@ -40,7 +40,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
 // This class exists in the main app domain
 //
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /**
      * @brief Array objects.

--- a/OpenSim/Region/ScriptEngine/YEngine/XMREngXmrTestLs.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMREngXmrTestLs.cs
@@ -44,7 +44,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 using SharedEventParams = OpenSim.Region.ScriptEngine.Shared.EventParams;
 using SharedScriptBaseClass = OpenSim.Region.ScriptEngine.Shared.ScriptBase.ScriptBaseClass;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class Yengine
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMREngine.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMREngine.cs
@@ -64,7 +64,7 @@ using SceneScriptEvents = OpenSim.Region.Framework.Scenes.scriptEvents;
 [assembly: Addin("YEngine", OpenSim.VersionInfo.VersionNumber)]
 [assembly: AddinDependency("OpenSim.Region.Framework", OpenSim.VersionInfo.VersionNumber)]
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     [Mono.Addins.Extension(Path = "/OpenSim/RegionModules", NodeName = "RegionModule", Id = "YEngine")]
     public partial class Yengine: INonSharedRegionModule, IScriptEngine, IScriptModule

--- a/OpenSim/Region/ScriptEngine/YEngine/XMREvents.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMREvents.cs
@@ -40,7 +40,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /// <summary>
     /// Prepares events so they can be directly executed upon a script by EventQueueManager, then queues it.

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRHeapTracker.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRHeapTracker.cs
@@ -37,7 +37,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /**
      * One instance of this class for lsl base objects that take a variable

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstAbstract.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstAbstract.cs
@@ -42,7 +42,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public class XMRInstArrays
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstBackend.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstBackend.cs
@@ -42,7 +42,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /****************************************************\
      *  This file contains routines called by scripts.  *

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstCapture.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstCapture.cs
@@ -41,7 +41,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class XMRInstance
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstCtor.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstCtor.cs
@@ -52,7 +52,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class XMRInstance
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstMain.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstMain.cs
@@ -39,7 +39,7 @@ using log4net;
 
 // This class exists in the main app domain
 //
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /**
      * @brief Which queue it is in as far as running is concerned,

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstMisc.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstMisc.cs
@@ -43,7 +43,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
 // This class exists in the main app domain
 //
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class XMRInstance
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstQueue.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstQueue.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /**
      * @brief Implements a queue of XMRInstance's.

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRInstRun.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRInstRun.cs
@@ -37,7 +37,7 @@ using OpenSim.Region.ScriptEngine.Shared.Api;
 using OpenSim.Region.ScriptEngine.Shared.ScriptBase;
 using OpenSim.Region.Framework.Scenes;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public partial class XMRInstance
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRObjectTokens.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRObjectTokens.cs
@@ -46,7 +46,7 @@ using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
  * See xmrengcomp.cx utility program.
  */
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     /*
      * Encapsulate object code for a method.

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRSDTypeClObj.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRSDTypeClObj.cs
@@ -36,7 +36,7 @@ using LSL_Rotation = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Quaternion;
 using LSL_String = OpenSim.Region.ScriptEngine.Shared.LSL_Types.LSLString;
 using LSL_Vector = OpenSim.Region.ScriptEngine.Shared.LSL_Types.Vector3;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
     public class XMRSDTypeClObj
     {

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRScriptThread.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRScriptThread.cs
@@ -31,7 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public partial class Yengine

--- a/OpenSim/Region/ScriptEngine/YEngine/XMRScriptUThread.cs
+++ b/OpenSim/Region/ScriptEngine/YEngine/XMRScriptUThread.cs
@@ -31,7 +31,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 
-namespace OpenSim.Region.ScriptEngine.Yengine
+namespace MutSea.Region.ScriptEngine.Yengine
 {
 
     public partial class XMRInstance


### PR DESCRIPTION
## Summary
- rename OpenSim namespaces under ScriptEngine to start with `MutSea`

## Testing
- `nant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8a58108483328d9a1acae3fdfc8d