### PR TITLE
Switch framework namespaces to MutSea

### DIFF
--- a/OpenSim/Region/Framework/Interfaces/IAgentAssetTransactions.cs
+++ b/OpenSim/Region/Framework/Interfaces/IAgentAssetTransactions.cs
@@ -26,10 +26,10 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IAgentAssetTransactions
     {

--- a/OpenSim/Region/Framework/Interfaces/IAgentStatefulModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IAgentStatefulModule.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IAgentStatefulModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IAttachmentsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IAttachmentsModule.cs
@@ -29,10 +29,10 @@ using System;
 using System.Xml;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IAttachmentsModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IAvatarFactoryModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IAvatarFactoryModule.cs
@@ -27,9 +27,9 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void ReportOutputAction(string format, params object[] args);
 

--- a/OpenSim/Region/Framework/Interfaces/IBakedTextureModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IBakedTextureModule.cs
@@ -25,10 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 
-namespace OpenSim.Services.Interfaces
+namespace MutSea.Services.Interfaces
 {
     public interface IBakedTextureModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IBuySellModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IBuySellModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IBuySellModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ICallingCardModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ICallingCardModule.cs
@@ -29,9 +29,9 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Framework
+namespace MutSea.Framework
 {
     public interface ICallingCardModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ICapabilitiesModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ICapabilitiesModule.cs
@@ -27,10 +27,10 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using Caps=OpenSim.Framework.Capabilities.Caps;
+using MutSea.Framework;
+using Caps=MutSea.Framework.Capabilities.Caps;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ICapabilitiesModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ICommand.cs
+++ b/OpenSim/Region/Framework/Interfaces/ICommand.cs
@@ -27,7 +27,7 @@
 
 using System.Collections.Generic;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public enum CommandIntentions
     {

--- a/OpenSim/Region/Framework/Interfaces/ICommandableModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ICommandableModule.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ICommandableModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ICommander.cs
+++ b/OpenSim/Region/Framework/Interfaces/ICommander.cs
@@ -27,7 +27,7 @@
 
 using System.Collections.Generic;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ICommander
     {

--- a/OpenSim/Region/Framework/Interfaces/IDialogModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IDialogModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IDialogModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IDwellModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IDwellModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IDwellModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IDynamicFloaterModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IDynamicFloaterModule.cs
@@ -27,10 +27,10 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate bool HandlerDelegate(IClientAPI client, FloaterData data, string[] msg);
 

--- a/OpenSim/Region/Framework/Interfaces/IDynamicMenuModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IDynamicMenuModule.cs
@@ -27,9 +27,9 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public enum InsertLocation : int
     {

--- a/OpenSim/Region/Framework/Interfaces/IDynamicTextureManager.cs
+++ b/OpenSim/Region/Framework/Interfaces/IDynamicTextureManager.cs
@@ -30,7 +30,7 @@ using System.Drawing;
 using System.IO;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IDynamicTextureManager
     {

--- a/OpenSim/Region/Framework/Interfaces/IEmailModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEmailModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public class Email
     {

--- a/OpenSim/Region/Framework/Interfaces/IEntityCreator.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEntityCreator.cs
@@ -26,10 +26,10 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Interface to a class that is capable of creating entities

--- a/OpenSim/Region/Framework/Interfaces/IEntityInventory.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEntityInventory.cs
@@ -29,10 +29,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Interface to an entity's (SceneObjectPart's) inventory

--- a/OpenSim/Region/Framework/Interfaces/IEntityTransferModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEntityTransferModule.cs
@@ -26,13 +26,13 @@
  */
 
 using System.Collections.Generic;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
 
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate ScenePresence CrossAgentToNewRegionDelegate(ScenePresence agent, Vector3 pos, GridRegion neighbourRegion, bool isFlying, EntityTransferContext ctx);
     public delegate ScenePresence CrossAsyncDelegate(ScenePresence agent, bool isFlying);

--- a/OpenSim/Region/Framework/Interfaces/IEnvironmentModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEnvironmentModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IEnvironmentModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IEstateModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEstateModule.cs
@@ -27,11 +27,11 @@
 
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Services.Interfaces;
 using System.Collections.Generic;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void ChangeDelegate(UUID regionID);
     public delegate void MessageDelegate(UUID regionID, UUID fromID, string fromName, string message);

--- a/OpenSim/Region/Framework/Interfaces/IEventQueue.cs
+++ b/OpenSim/Region/Framework/Interfaces/IEventQueue.cs
@@ -32,9 +32,9 @@ using OpenMetaverse;
 using OpenMetaverse.Packets;
 using OpenMetaverse.Messages.Linden;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public struct GroupChatListAgentUpdateData
     {

--- a/OpenSim/Region/Framework/Interfaces/IExternalCapsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IExternalCapsModule.cs
@@ -27,10 +27,10 @@
 
 using System;
 using OpenMetaverse;
-using OpenSim.Framework;
-using Caps=OpenSim.Framework.Capabilities.Caps;
+using MutSea.Framework;
+using Caps=MutSea.Framework.Capabilities.Caps;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IExternalCapsModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IFriendsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IFriendsModule.cs
@@ -27,11 +27,11 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using FriendInfo = OpenSim.Services.Interfaces.FriendInfo;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using FriendInfo = MutSea.Services.Interfaces.FriendInfo;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IFriendsModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IGodsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IGodsModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// This interface provides god related methods

--- a/OpenSim/Region/Framework/Interfaces/IGroupsMessagingModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IGroupsMessagingModule.cs
@@ -27,9 +27,9 @@
 
 using System;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Provide mechanisms for messaging groups.

--- a/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IGroupsModule.cs
@@ -27,9 +27,9 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void NewGroupNotice(UUID groupID, UUID noticeID);
 

--- a/OpenSim/Region/Framework/Interfaces/IHttpRequests.cs
+++ b/OpenSim/Region/Framework/Interfaces/IHttpRequests.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public enum HttpRequestConstants
     {

--- a/OpenSim/Region/Framework/Interfaces/IInventoryAccessModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IInventoryAccessModule.cs
@@ -28,12 +28,12 @@
 using System;
 using System.Collections.Generic;
 
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IInventoryAccessModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IInventoryArchiverModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IInventoryArchiverModule.cs
@@ -28,10 +28,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using OpenSim.Services.Interfaces;
+using MutSea.Services.Interfaces;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Used for the OnInventoryArchiveSaved event.

--- a/OpenSim/Region/Framework/Interfaces/IInventoryTransferModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IInventoryTransferModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// An interface for a module that manages inter-agent inventory offers and transfers.

--- a/OpenSim/Region/Framework/Interfaces/IJ2KDecoder.cs
+++ b/OpenSim/Region/Framework/Interfaces/IJ2KDecoder.cs
@@ -29,7 +29,7 @@ using System.Drawing;
 using OpenMetaverse;
 using OpenMetaverse.Imaging;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void DecodedCallback(UUID AssetId, OpenJPEG.J2KLayerInfo[] layers);
 

--- a/OpenSim/Region/Framework/Interfaces/IJsonStoreModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IJsonStoreModule.cs
@@ -29,7 +29,7 @@ using System;
 using System.Reflection;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     // these could be expanded at some point to provide more type information
     // for now value accounts for all base types

--- a/OpenSim/Region/Framework/Interfaces/ILightShareModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ILightShareModule.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ILightShareModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IMapImageUploadModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IMapImageUploadModule.cs
@@ -26,10 +26,10 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 using System.Drawing;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IMapImageUploadModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IMaterialsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IMaterialsModule.cs
@@ -25,10 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IMaterialsModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IMessageTransferModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IMessageTransferModule.cs
@@ -25,9 +25,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void MessageResultNotification(bool success);
     public delegate void UndeliveredMessage(GridInstantMessage im);

--- a/OpenSim/Region/Framework/Interfaces/IMoapModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IMoapModule.cs
@@ -27,9 +27,9 @@
 
 using System;
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Provides methods from manipulating media-on-a-prim

--- a/OpenSim/Region/Framework/Interfaces/INPCModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/INPCModule.cs
@@ -26,10 +26,10 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     // option flags for NPCs
     public enum NPCOptionsFlags : int

--- a/OpenSim/Region/Framework/Interfaces/INonSharedRegionModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/INonSharedRegionModule.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface INonSharedRegionModule : IRegionModuleBase
     {

--- a/OpenSim/Region/Framework/Interfaces/IPermissionsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IPermissionsModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <value>
     /// Which set of permissions a user has.

--- a/OpenSim/Region/Framework/Interfaces/IPresenceModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IPresenceModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public struct PresenceInfo
     {

--- a/OpenSim/Region/Framework/Interfaces/IPrimCountModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IPrimCountModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IPrimCountModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IProfileModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IProfileModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Framework
+namespace MutSea.Framework
 {
     public interface IProfileModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IRegionArchiverModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionArchiverModule.cs
@@ -31,7 +31,7 @@ using System.IO;
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// Interface to region archive functionality

--- a/OpenSim/Region/Framework/Interfaces/IRegionConsole.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionConsole.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void ConsoleMessage(UUID toAgentID, string message);
 

--- a/OpenSim/Region/Framework/Interfaces/IRegionModuleBase.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionModuleBase.cs
@@ -28,11 +28,11 @@
 using System;
 using Mono.Addins;
 using Nini.Config;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
-    [TypeExtensionPoint(Path = "/OpenSim/RegionModules", NodeName="RegionModule")]
+    [TypeExtensionPoint(Path = "/MutSea/RegionModules", NodeName="RegionModule")]
     public interface IRegionModuleBase
     {
         /// <value>

--- a/OpenSim/Region/Framework/Interfaces/IRegionModulesController.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionModulesController.cs
@@ -26,9 +26,9 @@
  */
 
 using System;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IRegionModulesController
     {

--- a/OpenSim/Region/Framework/Interfaces/IRegionReadyModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionReadyModule.cs
@@ -26,9 +26,9 @@
  */
 
 using System;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IRegionReadyModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IRegionSerialiserModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRegionSerialiserModule.cs
@@ -28,9 +28,9 @@
 using System.Collections.Generic;
 using System.IO;
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IRegionSerialiserModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IRestartModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IRestartModule.cs
@@ -28,7 +28,7 @@
 using System;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IRestartModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ISceneCommandsModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISceneCommandsModule.cs
@@ -28,10 +28,10 @@
 using System;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISceneCommandsModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IScenePresence.cs
+++ b/OpenSim/Region/Framework/Interfaces/IScenePresence.cs
@@ -27,10 +27,10 @@
 
 using System;
 using System.Collections.Generic;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     /// <summary>
     /// An agent in the scene.

--- a/OpenSim/Region/Framework/Interfaces/IScriptModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IScriptModule.cs
@@ -30,7 +30,7 @@ using System.Collections;
 using System.Collections.Generic;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void ScriptRemoved(UUID script);
     public delegate void ObjectRemoved(UUID prim);

--- a/OpenSim/Region/Framework/Interfaces/IScriptModuleComms.cs
+++ b/OpenSim/Region/Framework/Interfaces/IScriptModuleComms.cs
@@ -30,7 +30,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void ScriptCommand(UUID script, string id, string module, string command, string k);
 
@@ -38,7 +38,7 @@ namespace OpenSim.Region.Framework.Interfaces
     /// Interface for communication between OpenSim modules and in-world scripts
     /// </summary>
     ///
-    /// See OpenSim.Region.ScriptEngine.Shared.Api.MOD_Api.modSendCommand() for information on receiving messages
+    /// See MutSea.Region.ScriptEngine.Shared.Api.MOD_Api.modSendCommand() for information on receiving messages
     /// from scripts in OpenSim modules.
     public interface IScriptModuleComms
     {
@@ -115,7 +115,7 @@ namespace OpenSim.Region.Framework.Interfaces
         /// </param>
         /// <param name="value">
         /// The value of the constant. Should be of a type that can be
-        /// converted to one of <see cref="OpenSim.Region.ScriptEngine.Shared.LSL_Types"/>
+        /// converted to one of <see cref="MutSea.Region.ScriptEngine.Shared.LSL_Types"/>
         /// </param>
         void RegisterConstant(string cname, object value);
 

--- a/OpenSim/Region/Framework/Interfaces/ISearchModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISearchModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Framework
+namespace MutSea.Framework
 {
     public interface ISearchModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IServiceRequest.cs
+++ b/OpenSim/Region/Framework/Interfaces/IServiceRequest.cs
@@ -26,7 +26,7 @@
  */
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IServiceRequest
     {

--- a/OpenSim/Region/Framework/Interfaces/IServiceThrottleModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IServiceThrottleModule.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IServiceThrottleModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ISharedRegionModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISharedRegionModule.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISharedRegionModule : IRegionModuleBase
     {

--- a/OpenSim/Region/Framework/Interfaces/ISimulationDataService.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISimulationDataService.cs
@@ -28,10 +28,10 @@
 using System;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISimulationDataService
     {

--- a/OpenSim/Region/Framework/Interfaces/ISimulationDataStore.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISimulationDataStore.cs
@@ -27,10 +27,10 @@
 
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISimulationDataStore
     {

--- a/OpenSim/Region/Framework/Interfaces/ISimulatorFeaturesModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISimulatorFeaturesModule.cs
@@ -29,7 +29,7 @@ using System;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public delegate void SimulatorFeaturesRequestDelegate(UUID agentID, ref OSDMap features);
 

--- a/OpenSim/Region/Framework/Interfaces/ISnmpModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISnmpModule.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
 public interface ISnmpModule
 {

--- a/OpenSim/Region/Framework/Interfaces/ISoundModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISoundModule.cs
@@ -27,9 +27,9 @@
 
 using System;
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISoundModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ISunModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ISunModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ISunModule : INonSharedRegionModule
     {

--- a/OpenSim/Region/Framework/Interfaces/ITerrain.cs
+++ b/OpenSim/Region/Framework/Interfaces/ITerrain.cs
@@ -25,10 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ITerrain
     {

--- a/OpenSim/Region/Framework/Interfaces/ITerrainChannel.cs
+++ b/OpenSim/Region/Framework/Interfaces/ITerrainChannel.cs
@@ -25,10 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ITerrainChannel
     {

--- a/OpenSim/Region/Framework/Interfaces/ITerrainEffect.cs
+++ b/OpenSim/Region/Framework/Interfaces/ITerrainEffect.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ITerrainEffect
     {

--- a/OpenSim/Region/Framework/Interfaces/ITerrainModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/ITerrainModule.cs
@@ -26,10 +26,10 @@
  */
 
 using System.IO;
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface ITerrainModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IUrlModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IUrlModule.cs
@@ -28,10 +28,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IUrlModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IUserAccountCacheModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IUserAccountCacheModule.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 using OpenMetaverse;
 
 public interface IUserAccountCacheModule

--- a/OpenSim/Region/Framework/Interfaces/IVegetationModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IVegetationModule.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IVegetationModule : IEntityCreator
     {

--- a/OpenSim/Region/Framework/Interfaces/IVoiceModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IVoiceModule.cs
@@ -29,7 +29,7 @@
 using System.IO;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IVoiceModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IWindModelPlugin.cs
+++ b/OpenSim/Region/Framework/Interfaces/IWindModelPlugin.cs
@@ -29,13 +29,13 @@ using System;
 using System.Collections.Generic;
 
 using Nini.Config;
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
 using Mono.Addins;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     [TypeExtensionPoint(Path = "/OpenSim/WindModule", NodeName = "WindModel")]
     public interface IWindModelPlugin : IPlugin

--- a/OpenSim/Region/Framework/Interfaces/IWindModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IWindModule.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IWindModule : INonSharedRegionModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IWorldComm.cs
+++ b/OpenSim/Region/Framework/Interfaces/IWorldComm.cs
@@ -27,9 +27,9 @@
 
 using System;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IWorldCommListenerInfo
     {

--- a/OpenSim/Region/Framework/Interfaces/IWorldMapModule.cs
+++ b/OpenSim/Region/Framework/Interfaces/IWorldMapModule.cs
@@ -25,10 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 using System.Collections.Generic;
-using OpenSim.Framework;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Services.Interfaces;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IWorldMapModule
     {

--- a/OpenSim/Region/Framework/Interfaces/IXMLRPC.cs
+++ b/OpenSim/Region/Framework/Interfaces/IXMLRPC.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IXmlRpcRequestInfo
     {

--- a/OpenSim/Region/Framework/Interfaces/IXfer.cs
+++ b/OpenSim/Region/Framework/Interfaces/IXfer.cs
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IXfer
     {

--- a/OpenSim/Region/Framework/Interfaces/IXmlRpcRouter.cs
+++ b/OpenSim/Region/Framework/Interfaces/IXmlRpcRouter.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Interfaces
+namespace MutSea.Region.Framework.Interfaces
 {
     public interface IXmlRpcRouter
     {

--- a/OpenSim/Region/Framework/Properties/AssemblyInfo.cs
+++ b/OpenSim/Region/Framework/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using Mono.Addins;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion(OpenSim.VersionInfo.AssemblyVersionNumber)]
-[assembly: AddinRoot("OpenSim.Region.Framework", OpenSim.VersionInfo.VersionNumber)]
+[assembly: AssemblyVersion(MutSea.VersionInfo.AssemblyVersionNumber)]
+[assembly: AddinRoot("MutSea.Region.Framework", MutSea.VersionInfo.VersionNumber)]
 

--- a/OpenSim/Region/Framework/Scenes/Animation/AnimationSet.cs
+++ b/OpenSim/Region/Framework/Scenes/Animation/AnimationSet.cs
@@ -33,27 +33,27 @@ using log4net;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 
-using OpenSim.Framework;
+using MutSea.Framework;
 
-using Animation = OpenSim.Framework.Animation;
+using Animation = MutSea.Framework.Animation;
 
-namespace OpenSim.Region.Framework.Scenes.Animation
+namespace MutSea.Region.Framework.Scenes.Animation
 {
     [Serializable]
     public class AnimationSet
     {
         //private static readonly ILog m_log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        private OpenSim.Framework.Animation m_implicitDefaultAnimation = new OpenSim.Framework.Animation();
-        private OpenSim.Framework.Animation m_defaultAnimation = new OpenSim.Framework.Animation();
-        private readonly List<OpenSim.Framework.Animation> m_animations = new List<OpenSim.Framework.Animation>();
+        private MutSea.Framework.Animation m_implicitDefaultAnimation = new MutSea.Framework.Animation();
+        private MutSea.Framework.Animation m_defaultAnimation = new MutSea.Framework.Animation();
+        private readonly List<MutSea.Framework.Animation> m_animations = new List<MutSea.Framework.Animation>();
 
-        public OpenSim.Framework.Animation DefaultAnimation
+        public MutSea.Framework.Animation DefaultAnimation
         {
             get { return m_defaultAnimation; }
         }
 
-        public OpenSim.Framework.Animation ImplicitDefaultAnimation
+        public MutSea.Framework.Animation ImplicitDefaultAnimation
         {
             get { return m_implicitDefaultAnimation; }
         }
@@ -89,7 +89,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
             {
                 if (!HasAnimation(animID))
                 {
-                    m_animations.Add(new OpenSim.Framework.Animation(animID, sequenceNum, objectID));
+                    m_animations.Add(new MutSea.Framework.Animation(animID, sequenceNum, objectID));
                     return true;
                 }
             }
@@ -111,7 +111,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
                 if (m_defaultAnimation.AnimID.Equals(animID))
                 {
                     if (allowNoDefault)
-                        m_defaultAnimation = new OpenSim.Framework.Animation(UUID.Zero, 1, UUID.Zero);
+                        m_defaultAnimation = new MutSea.Framework.Animation(UUID.Zero, 1, UUID.Zero);
                     else
                         ResetDefaultAnimation();
                 }
@@ -144,7 +144,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
         {
             if (m_defaultAnimation.AnimID.NotEqual(animID))
             {
-                m_defaultAnimation = new OpenSim.Framework.Animation(animID, sequenceNum, objectID);
+                m_defaultAnimation = new MutSea.Framework.Animation(animID, sequenceNum, objectID);
                 m_implicitDefaultAnimation = m_defaultAnimation;
                 //return true;
             }
@@ -155,7 +155,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
         // Called from serialization only
         public void SetImplicitDefaultAnimation(UUID animID, int sequenceNum, UUID objectID)
         {
-            m_implicitDefaultAnimation = new OpenSim.Framework.Animation(animID, sequenceNum, objectID);
+            m_implicitDefaultAnimation = new MutSea.Framework.Animation(animID, sequenceNum, objectID);
         }
 
         protected bool ResetDefaultAnimation()
@@ -227,25 +227,25 @@ namespace OpenSim.Region.Framework.Scenes.Animation
             }
         }
 
-        public OpenSim.Framework.Animation[] ToArray()
+        public MutSea.Framework.Animation[] ToArray()
         {
-            OpenSim.Framework.Animation[] theArray = null;
+            MutSea.Framework.Animation[] theArray = null;
             try
             {
                 theArray = m_animations.ToArray();
             }
             catch
             {
-                return new OpenSim.Framework.Animation[0];
+                return new MutSea.Framework.Animation[0];
             }
 
             return theArray;
         }
 
-        public int FromArray(OpenSim.Framework.Animation[] theArray)
+        public int FromArray(MutSea.Framework.Animation[] theArray)
         {
             int ret = 0;
-            foreach (OpenSim.Framework.Animation anim in theArray)
+            foreach (MutSea.Framework.Animation anim in theArray)
             { 
                 m_animations.Add(anim);
                 if(anim.SequenceNum > ret)
@@ -263,7 +263,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
             ret.Add(DefaultAnimation.PackUpdateMessage());
             ret.Add(ImplicitDefaultAnimation.PackUpdateMessage());
 
-            foreach (OpenSim.Framework.Animation anim in m_animations)
+            foreach (MutSea.Framework.Animation anim in m_animations)
                 ret.Add(anim.PackUpdateMessage());
 
             return ret;
@@ -275,15 +275,15 @@ namespace OpenSim.Region.Framework.Scenes.Animation
 
             if (pArray.Count >= 1)
             {
-                m_defaultAnimation = new OpenSim.Framework.Animation((OSDMap)pArray[0]);
+                m_defaultAnimation = new MutSea.Framework.Animation((OSDMap)pArray[0]);
             }
             if (pArray.Count >= 2)
             {
-                m_implicitDefaultAnimation = new OpenSim.Framework.Animation((OSDMap)pArray[1]);
+                m_implicitDefaultAnimation = new MutSea.Framework.Animation((OSDMap)pArray[1]);
             }
             for (int ii = 2; ii < pArray.Count; ii++)
             {
-                m_animations.Add(new OpenSim.Framework.Animation((OSDMap)pArray[ii]));
+                m_animations.Add(new MutSea.Framework.Animation((OSDMap)pArray[ii]));
             }
         }
 
@@ -298,17 +298,17 @@ namespace OpenSim.Region.Framework.Scenes.Animation
                     && this.ImplicitDefaultAnimation.Equals(other.ImplicitDefaultAnimation))
                 {
                     // The defaults are the same. Is the list of animations the same?
-                    OpenSim.Framework.Animation[] thisAnims = this.ToArray();
-                    OpenSim.Framework.Animation[] otherAnims = other.ToArray();
+                    MutSea.Framework.Animation[] thisAnims = this.ToArray();
+                    MutSea.Framework.Animation[] otherAnims = other.ToArray();
                     if (thisAnims.Length == 0 && otherAnims.Length == 0)
                         return true;    // the common case
                     if (thisAnims.Length == otherAnims.Length)
                     {
                         // Do this the hard way but since the list is usually short this won't take long.
-                        foreach (OpenSim.Framework.Animation thisAnim in thisAnims)
+                        foreach (MutSea.Framework.Animation thisAnim in thisAnims)
                         {
                             bool found = false;
-                            foreach (OpenSim.Framework.Animation otherAnim in otherAnims)
+                            foreach (MutSea.Framework.Animation otherAnim in otherAnims)
                             {
                                 if (thisAnim.Equals(otherAnim))
                                 {
@@ -351,7 +351,7 @@ namespace OpenSim.Region.Framework.Scenes.Animation
             {
                 buff.Append(",anims=");
                 bool firstTime = true;
-                foreach (OpenSim.Framework.Animation anim in m_animations)
+                foreach (MutSea.Framework.Animation anim in m_animations)
                 {
                     if (!firstTime)
                         buff.Append(",");

--- a/OpenSim/Region/Framework/Scenes/Animation/BinBVHAnimation.cs
+++ b/OpenSim/Region/Framework/Scenes/Animation/BinBVHAnimation.cs
@@ -29,7 +29,7 @@ using System;
 using System.IO;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Scenes.Animation
+namespace MutSea.Region.Framework.Scenes.Animation
 {
     /// <summary>
     /// Written to decode and encode a binary animation asset.

--- a/OpenSim/Region/Framework/Scenes/Animation/DefaultAvatarAnimations.cs
+++ b/OpenSim/Region/Framework/Scenes/Animation/DefaultAvatarAnimations.cs
@@ -31,7 +31,7 @@ using System.Xml;
 using log4net;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Scenes.Animation
+namespace MutSea.Region.Framework.Scenes.Animation
 {
     public class DefaultAvatarAnimations
     {

--- a/OpenSim/Region/Framework/Scenes/Animation/MovementAnimationOverrides.cs
+++ b/OpenSim/Region/Framework/Scenes/Animation/MovementAnimationOverrides.cs
@@ -35,16 +35,16 @@ using Timer = System.Timers.Timer;
 using OpenMetaverse;
 using log4net;
 using Nini.Config;
-using OpenSim.Framework;
-using OpenSim.Framework.Client;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Animation;
-using OpenSim.Region.Framework.Scenes.Types;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Framework.Client;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Animation;
+using MutSea.Region.Framework.Scenes.Types;
+using MutSea.Region.PhysicsModules.SharedBase;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
+using MutSea.Services.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class MovementAnimationOverrides
     {

--- a/OpenSim/Region/Framework/Scenes/Animation/ScenePresenceAnimator.cs
+++ b/OpenSim/Region/Framework/Scenes/Animation/ScenePresenceAnimator.cs
@@ -32,12 +32,12 @@ using System.Reflection;
 using System.Threading;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.PhysicsModules.SharedBase;
 
-namespace OpenSim.Region.Framework.Scenes.Animation
+namespace MutSea.Region.Framework.Scenes.Animation
 {
     /// <summary>
     /// Handle all animation duties for a scene presence

--- a/OpenSim/Region/Framework/Scenes/AsyncInventorySender.cs
+++ b/OpenSim/Region/Framework/Scenes/AsyncInventorySender.cs
@@ -32,10 +32,10 @@ using System.Collections.Concurrent;
 using System.Threading;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     class FetchHolder
     {

--- a/OpenSim/Region/Framework/Scenes/AsyncSceneObjectGroupDeleter.cs
+++ b/OpenSim/Region/Framework/Scenes/AsyncSceneObjectGroupDeleter.cs
@@ -32,10 +32,10 @@ using System.Collections.Concurrent;
 using System.Threading;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     class DeleteToInventoryHolder
     {

--- a/OpenSim/Region/Framework/Scenes/Cardinals.cs
+++ b/OpenSim/Region/Framework/Scenes/Cardinals.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public enum Cardinals
     {

--- a/OpenSim/Region/Framework/Scenes/CoalescedSceneObjects.cs
+++ b/OpenSim/Region/Framework/Scenes/CoalescedSceneObjects.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// Represents a coalescene of scene objects.  A coalescence occurs when objects that are not in the same linkset

--- a/OpenSim/Region/Framework/Scenes/CollisionSounds.cs
+++ b/OpenSim/Region/Framework/Scenes/CollisionSounds.cs
@@ -30,10 +30,10 @@ using System;
 using System.Reflection;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 using log4net;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public struct CollisionForSoundInfo
     {

--- a/OpenSim/Region/Framework/Scenes/EntityBase.cs
+++ b/OpenSim/Region/Framework/Scenes/EntityBase.cs
@@ -30,11 +30,11 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 using log4net;
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 using System.Runtime.CompilerServices;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public abstract class EntityBase : ISceneEntity
     {

--- a/OpenSim/Region/Framework/Scenes/EntityManager.cs
+++ b/OpenSim/Region/Framework/Scenes/EntityManager.cs
@@ -31,9 +31,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class EntityManager
     {

--- a/OpenSim/Region/Framework/Scenes/EntityUpdates.cs
+++ b/OpenSim/Region/Framework/Scenes/EntityUpdates.cs
@@ -27,9 +27,9 @@
 
 using System;
 using System.Collections.Generic;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// Specifies the fields that have been changed when sending a prim or

--- a/OpenSim/Region/Framework/Scenes/EventManager.cs
+++ b/OpenSim/Region/Framework/Scenes/EventManager.cs
@@ -30,13 +30,13 @@ using System.Collections.Generic;
 using System.Reflection;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Client;
-using OpenSim.Region.Framework.Interfaces;
-using Caps = OpenSim.Framework.Capabilities.Caps;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using MutSea.Framework;
+using MutSea.Framework.Client;
+using MutSea.Region.Framework.Interfaces;
+using Caps = MutSea.Framework.Capabilities.Caps;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// A class for triggering remote scene events.
@@ -49,7 +49,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered on each sim frame.
         /// </summary>
         /// <remarks>
-        /// This gets triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.Update"/>
+        /// This gets triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.Update"/>
         /// Core uses it for things like Sun, Wind & Clouds
         /// The MRM module also uses it.
         /// </remarks>
@@ -60,8 +60,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Trigerred when an agent moves.
         /// </summary>
         /// <remarks>
-        /// This gets triggered in <see cref="OpenSim.Region.Framework.Scenes.ScenePresence.HandleAgentUpdate"/>
-        /// prior to <see cref="OpenSim.Region.Framework.Scenes.ScenePresence.TriggerScenePresenceUpdated"/>
+        /// This gets triggered in <see cref="MutSea.Region.Framework.Scenes.ScenePresence.HandleAgentUpdate"/>
+        /// prior to <see cref="MutSea.Region.Framework.Scenes.ScenePresence.TriggerScenePresenceUpdated"/>
         /// </remarks>
         public delegate void ClientMovement(ScenePresence client);
         public event ClientMovement OnClientMovement;
@@ -70,7 +70,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered if the terrain has been edited
         /// </summary>
         /// <remarks>
-        /// This gets triggered in <see cref="OpenSim.Region.CoreModules.World.Terrain.CheckForTerrainUpdates"/>
+        /// This gets triggered in <see cref="MutSea.Region.CoreModules.World.Terrain.CheckForTerrainUpdates"/>
         /// after it determines that an update has been made.
         /// </remarks>
         public delegate void OnTerrainTaintedDelegate();
@@ -80,7 +80,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered if the terrain has been edited
         /// </summary>
         /// <remarks>
-        /// This gets triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.UpdateTerrain"/>
+        /// This gets triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.UpdateTerrain"/>
         /// but is used by core solely to update the physics engine.
         /// </remarks>
         public delegate void OnTerrainTickDelegate();
@@ -96,7 +96,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when a region is backed up/persisted to storage
         /// </summary>
         /// <remarks>
-        /// This gets triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.Backup"/>
+        /// This gets triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.Backup"/>
         /// and is fired before the persistence occurs.
         /// </remarks>
         public delegate void OnBackupDelegate(ISimulationDataService datastore, bool forceBackup);
@@ -107,9 +107,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// This gets triggered in <see cref="TriggerOnNewClient"/>,
-        /// which checks if an instance of <see cref="OpenSim.Framework.IClientAPI"/>
-        /// also implements <see cref="OpenSim.Framework.Client.IClientCore"/> and as such,
-        /// is not triggered by <see cref="OpenSim.Region.OptionalModules.World.NPC">NPCs</see>.
+        /// which checks if an instance of <see cref="MutSea.Framework.IClientAPI"/>
+        /// also implements <see cref="MutSea.Framework.Client.IClientCore"/> and as such,
+        /// is not triggered by <see cref="MutSea.Region.OptionalModules.World.NPC">NPCs</see>.
         /// </remarks>
         public delegate void OnClientConnectCoreDelegate(IClientCore client);
         public event OnClientConnectCoreDelegate OnClientConnect;
@@ -141,8 +141,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when a new presence is added to the scene
         /// </summary>
         /// <remarks>
-        /// Triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.AddNewAgent"/> which is used by both
-        /// <see cref="OpenSim.Framework.PresenceType.User">users</see> and <see cref="OpenSim.Framework.PresenceType.Npc">NPCs</see>
+        /// Triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.AddNewAgent"/> which is used by both
+        /// <see cref="MutSea.Framework.PresenceType.User">users</see> and <see cref="MutSea.Framework.PresenceType.Npc">NPCs</see>
         /// </remarks>
         public delegate void OnNewPresenceDelegate(ScenePresence presence);
         public event OnNewPresenceDelegate OnNewPresence;
@@ -151,8 +151,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when a presence is removed from the scene
         /// </summary>
         /// <remarks>
-        /// Triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.AddNewAgent"/> which is used by both
-        /// <see cref="OpenSim.Framework.PresenceType.User">users</see> and <see cref="OpenSim.Framework.PresenceType.Npc">NPCs</see>
+        /// Triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.AddNewAgent"/> which is used by both
+        /// <see cref="MutSea.Framework.PresenceType.User">users</see> and <see cref="MutSea.Framework.PresenceType.Npc">NPCs</see>
         ///
         /// Triggered under per-agent lock.  So if you want to perform any long-running operations, please
         /// do this on a separate thread.
@@ -167,12 +167,12 @@ namespace OpenSim.Region.Framework.Scenes
         /// <remarks>
         /// Triggered by <see cref="TriggerParcelPrimCountUpdate"/> in
         /// <see cref="OpenSim.OpenSimBase.CreateRegion"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandManagementModule.EventManagerOnRequestParcelPrimCountUpdate"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandManagementModule.ClientOnParcelObjectOwnerRequest"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandObject.GetPrimsFree"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandObject.UpdateLandSold"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandObject.DeedToGroup"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandObject.SendLandUpdateToClient"/>
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandManagementModule.EventManagerOnRequestParcelPrimCountUpdate"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandManagementModule.ClientOnParcelObjectOwnerRequest"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandObject.GetPrimsFree"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandObject.UpdateLandSold"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandObject.DeedToGroup"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandObject.SendLandUpdateToClient"/>
         /// </remarks>
         public delegate void OnParcelPrimCountUpdateDelegate();
         public event OnParcelPrimCountUpdateDelegate OnParcelPrimCountUpdate;
@@ -183,7 +183,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerParcelPrimCountAdd"/> in
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandManagementModule.EventManagerOnParcelPrimCountUpdate"/>
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandManagementModule.EventManagerOnParcelPrimCountUpdate"/>
         /// </remarks>
         public delegate void OnParcelPrimCountAddDelegate(SceneObjectGroup obj);
         public event OnParcelPrimCountAddDelegate OnParcelPrimCountAdd;
@@ -194,7 +194,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// loaded via <see cref="OpenSim.OpenSimBase.LoadPlugins"/>.
         /// Handlers for this event are typically used to parse the arguments
         /// from <see cref="OnPluginConsoleDelegate"/> in order to process or
-        /// filter the arguments and pass them onto <see cref="OpenSim.Region.CoreModules.Framework.InterfaceCommander.Commander.ProcessConsoleCommand"/>
+        /// filter the arguments and pass them onto <see cref="MutSea.Region.CoreModules.Framework.InterfaceCommander.Commander.ProcessConsoleCommand"/>
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerOnPluginConsole"/> in
@@ -232,8 +232,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerOnParcelPropertiesUpdateRequest"/> in
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandManagementModule.ClientOnParcelPropertiesUpdateRequest"/>,
-        /// <see cref="OpenSim.Region.CoreModules.World.Land.LandManagementModule.ProcessPropertiesUpdate"/>
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandManagementModule.ClientOnParcelPropertiesUpdateRequest"/>,
+        /// <see cref="MutSea.Region.CoreModules.World.Land.LandManagementModule.ProcessPropertiesUpdate"/>
         /// </remarks>
         public event ParcelPropertiesUpdateRequest OnParcelPropertiesUpdateRequest;
 
@@ -252,7 +252,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// <remarks>
         /// The originalID is the local ID of the part that was actually touched.  The localID itself is always that of
         /// the root part.
-        /// Triggerd in response to <see cref="OpenSim.Framework.IClientAPI.OnGrabObject"/>
+        /// Triggerd in response to <see cref="MutSea.Framework.IClientAPI.OnGrabObject"/>
         /// via <see cref="TriggerObjectGrab"/>
         /// in <see cref="Scene.ProcessObjectGrab"/>
         /// </remarks>
@@ -263,7 +263,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when an object is being touched/grabbed continuously.
         /// </summary>
         /// <remarks>
-        /// Triggered in response to <see cref="OpenSim.Framework.IClientAPI.OnGrabUpdate"/>
+        /// Triggered in response to <see cref="MutSea.Framework.IClientAPI.OnGrabUpdate"/>
         /// via <see cref="TriggerObjectGrabbing"/>
         /// in <see cref="Scene.ProcessObjectGrabUpdate"/>
         /// </remarks>
@@ -273,7 +273,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when an object stops being touched/grabbed.
         /// </summary>
         /// <remarks>
-        /// Triggered in response to <see cref="OpenSim.Framework.IClientAPI.OnDeGrabObject"/>
+        /// Triggered in response to <see cref="MutSea.Framework.IClientAPI.OnDeGrabObject"/>
         /// via <see cref="TriggerObjectDeGrab"/>
         /// in <see cref="Scene.ProcessObjectDeGrab"/>
         /// </remarks>
@@ -289,8 +289,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// <remarks>
         /// Triggered by <see cref="TriggerScriptReset"/>
         /// in <see cref="Scene.ProcessScriptReset"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnScriptReset"/>
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandleScriptReset"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnScriptReset"/>
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.LLClientView.HandleScriptReset"/>
         /// </remarks>
         public delegate void ScriptResetDelegate(uint localID, UUID itemID);
         public event ScriptResetDelegate OnScriptReset;
@@ -325,8 +325,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// <remarks>
         /// Triggered by <see cref="TriggerStartScript"/>
         /// in <see cref="Scene.SetScriptRunning"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnSetScriptRunning"/>,
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.HandleSetScriptRunning"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnSetScriptRunning"/>,
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.HandleSetScriptRunning"/>
         /// </remarks>
         public delegate void StartScript(uint localID, UUID itemID);
         public event StartScript OnStartScript;
@@ -362,8 +362,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// in <see cref="SceneObjectGroup.OnGrabGroup"/>
         /// via <see cref="SceneObjectGroup.ObjectGrabHandler"/>
         /// via <see cref="Scene.ProcessObjectGrab"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnGrabObject"/>
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandleObjectGrab"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnGrabObject"/>
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.LLClientView.HandleObjectGrab"/>
         /// </remarks>
         public delegate void SceneGroupGrabed(UUID groupID, Vector3 offset, UUID userID);
         public event SceneGroupGrabed OnSceneGroupGrab;
@@ -375,8 +375,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerGroupSpinStart"/>
         /// in <see cref="SceneObjectGroup.SpinStart"/>
         /// via <see cref="SceneGraph.SpinStart"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnSpinStart"/>
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandleObjectSpinStart"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnSpinStart"/>
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.LLClientView.HandleObjectSpinStart"/>
         /// </remarks>
         public delegate bool SceneGroupSpinStarted(UUID groupID);
         public event SceneGroupSpinStarted OnSceneGroupSpinStart;
@@ -388,8 +388,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerGroupSpin"/>
         /// in <see cref="SceneObjectGroup.SpinMovement"/>
         /// via <see cref="SceneGraph.SpinObject"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnSpinUpdate"/>
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandleObjectSpinUpdate"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnSpinUpdate"/>
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.LLClientView.HandleObjectSpinUpdate"/>
         /// </remarks>
         public delegate bool SceneGroupSpun(UUID groupID, Quaternion rotation);
         public event SceneGroupSpun OnSceneGroupSpin;
@@ -467,9 +467,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerUpdateScript"/>
         /// in <see cref="Scene.CapsUpdateTaskInventoryScriptAsset"/>
         /// via <see cref="Scene.CapsUpdateTaskInventoryScriptAsset"/>
-        /// via <see cref="OpenSim.Region.ClientStack.Linden.BunchOfCaps.TaskScriptUpdated"/>
-        /// via <see cref="OpenSim.Region.ClientStack.Linden.TaskInventoryScriptUpdater.OnUpLoad"/>
-        /// via <see cref="OpenSim.Region.ClientStack.Linden.TaskInventoryScriptUpdater.uploaderCaps"/>
+        /// via <see cref="MutSea.Region.ClientStack.Linden.BunchOfCaps.TaskScriptUpdated"/>
+        /// via <see cref="MutSea.Region.ClientStack.Linden.TaskInventoryScriptUpdater.OnUpLoad"/>
+        /// via <see cref="MutSea.Region.ClientStack.Linden.TaskInventoryScriptUpdater.uploaderCaps"/>
         /// </remarks>
         public delegate void UpdateScript(UUID clientID, UUID itemId, UUID primId, bool isScriptRunning, UUID newAssetID);
         public event UpdateScript OnUpdateScript;
@@ -504,7 +504,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// This event is sent to a script to tell it that some property changed on
         /// the object the script is in. See http://lslwiki.net/lslwiki/wakka.php?wakka=changed .
         /// Triggered by <see cref="TriggerOnScriptChangedEvent"/>
-        /// in <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.TeleportAgentWithinRegion"/>,
+        /// in <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.TeleportAgentWithinRegion"/>,
         /// <see cref="SceneObjectPart.TriggerScriptChangedEvent"/>
         /// </remarks>
         public delegate void ScriptChangedEvent(uint localID, uint change, object data);
@@ -518,8 +518,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerControlEvent"/>
         /// in <see cref="ScenePresence.SendControlsToScripts"/>
         /// via <see cref="ScenePresence.HandleAgentUpdate"/>
-        /// via <see cref="OpenSim.Framework.IClientAPI.OnAgentUpdate"/>
-        /// via <see cref="OpenSim.Region.ClientStack.LindenUDP.LLClientView.HandleAgentUpdate"/>
+        /// via <see cref="MutSea.Framework.IClientAPI.OnAgentUpdate"/>
+        /// via <see cref="MutSea.Region.ClientStack.LindenUDP.LLClientView.HandleAgentUpdate"/>
         /// </remarks>
         public delegate void ScriptControlEvent(UUID item, UUID avatarID, uint held, uint changed);
         public event ScriptControlEvent OnScriptControlEvent;
@@ -599,8 +599,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptCollidingStart"/>
         /// in <see cref="SceneObjectPart.SendCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptColliderStart;
 
@@ -613,8 +613,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptColliding"/>
         /// in <see cref="SceneObjectPart.SendCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptColliding;
 
@@ -626,8 +626,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptCollidingEnd"/>
         /// in <see cref="SceneObjectPart.SendCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptCollidingEnd;
 
@@ -639,8 +639,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptLandCollidingStart"/>
         /// in <see cref="SceneObjectPart.SendLandCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptLandColliderStart;
 
@@ -652,8 +652,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptLandColliding"/>
         /// in <see cref="SceneObjectPart.SendLandCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptLandColliding;
 
@@ -665,8 +665,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered by <see cref="TriggerScriptLandCollidingEnd"/>
         /// in <see cref="SceneObjectPart.SendLandCollisionEvent"/>
         /// via <see cref="SceneObjectPart.PhysicsCollision"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
-        /// via <see cref="OpenSim.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.OnCollisionUpdate"/>
+        /// via <see cref="MutSea.Region.PhysicsModule.SharedBase.PhysicsActor.SendCollisionUpdate"/>
         /// </remarks>
         public event ScriptColliding OnScriptLandColliderEnd;
 
@@ -676,9 +676,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// <remarks>
         /// Triggered by <see cref="TriggerOnMakeChildAgent"/>
         /// in <see cref="ScenePresence.MakeChildAgent"/>
-        /// via <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.CrossAgentToNewRegionAsync"/>,
-        /// <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>,
-        /// <see cref="OpenSim.Region.CoreModules.InterGrid.KillAUser.ShutdownNoLogout"/>
+        /// via <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.CrossAgentToNewRegionAsync"/>,
+        /// <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>,
+        /// <see cref="MutSea.Region.CoreModules.InterGrid.KillAUser.ShutdownNoLogout"/>
         /// </remarks>
         public delegate void OnMakeChildAgentDelegate(ScenePresence presence);
         public event OnMakeChildAgentDelegate OnMakeChildAgent;
@@ -796,8 +796,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerParcelPrimCountTainted"/> in
-        /// <see cref="OpenSim.Region.CoreModules.Avatar.Attachments.AttachmentsModule.DetachSingleAttachmentToGround"/>,
-        /// <see cref="OpenSim.Region.CoreModules.Avatar.Attachments.AttachmentsModule.AttachToAgent"/>,
+        /// <see cref="MutSea.Region.CoreModules.Avatar.Attachments.AttachmentsModule.DetachSingleAttachmentToGround"/>,
+        /// <see cref="MutSea.Region.CoreModules.Avatar.Attachments.AttachmentsModule.AttachToAgent"/>,
         /// <see cref="Scene.DeleteSceneObject"/>,
         /// <see cref="Scene.SelectPrim"/>,
         /// <see cref="Scene.DeselectPrim"/>,
@@ -910,7 +910,7 @@ namespace OpenSim.Region.Framework.Scenes
         /// <param name="original"></param>
         /// <param name="userExposed">True if the duplicate will immediately be in the scene, false otherwise</param>
         /// <remarks>
-        /// Triggered in <see cref="OpenSim.Region.Framework.Scenes.SceneObjectPart.Copy"/>
+        /// Triggered in <see cref="MutSea.Region.Framework.Scenes.SceneObjectPart.Copy"/>
         /// </remarks>
         public delegate void SceneObjectPartCopyDelegate(SceneObjectPart copy, SceneObjectPart original, bool userExposed);
         public event SceneObjectPartCopyDelegate OnSceneObjectPartCopy;
@@ -960,9 +960,9 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerTeleportStart"/>
-        /// in <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.CreateAgent"/>
-        /// and <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.HGEntityTransferModule.CreateAgent"/>
-        /// via <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>
+        /// in <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.CreateAgent"/>
+        /// and <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.HGEntityTransferModule.CreateAgent"/>
+        /// via <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>
         /// </remarks>
         public delegate void TeleportStart(IClientAPI client, GridRegion destination, GridRegion finalDestination, uint teleportFlags, bool gridLogout);
         public event TeleportStart OnTeleportStart;
@@ -972,8 +972,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// </summary>
         /// <remarks>
         /// Triggered by <see cref="TriggerTeleportFail"/>
-        /// in <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.Fail"/>
-        /// via <see cref="OpenSim.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>
+        /// in <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.Fail"/>
+        /// via <see cref="MutSea.Region.CoreModules.Framework.EntityTransfer.EntityTransferModule.DoTeleport"/>
         /// </remarks>
         public delegate void TeleportFail(IClientAPI client, bool gridLogout);
         public event TeleportFail OnTeleportFail;
@@ -1002,10 +1002,10 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered when an attempt to transfer grid currency occurs
         /// </summary>
         /// <remarks>
-        /// Triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.ProcessMoneyTransferRequest"/>
-        /// via <see cref="OpenSim.Region.Framework.Scenes.Scene.SubscribeToClientGridEvents"/>
-        /// via <see cref="OpenSim.Region.Framework.Scenes.Scene.SubscribeToClientEvents"/>
-        /// via <see cref="OpenSim.Region.Framework.Scenes.Scene.AddNewAgent"/>
+        /// Triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.ProcessMoneyTransferRequest"/>
+        /// via <see cref="MutSea.Region.Framework.Scenes.Scene.SubscribeToClientGridEvents"/>
+        /// via <see cref="MutSea.Region.Framework.Scenes.Scene.SubscribeToClientEvents"/>
+        /// via <see cref="MutSea.Region.Framework.Scenes.Scene.AddNewAgent"/>
         /// </remarks>
         public delegate void MoneyTransferEvent(Object sender, MoneyTransferArgs e);
         public event MoneyTransferEvent OnMoneyTransfer;
@@ -1053,8 +1053,8 @@ namespace OpenSim.Region.Framework.Scenes
         /// Triggered to allow or prevent a real estate transaction
         /// </summary>
         /// <remarks>
-        /// Triggered in <see cref="OpenSim.Region.Framework.Scenes.Scene.ProcessParcelBuy"/>
-        /// <seealso cref="OpenSim.Region.OptionalModules.World.MoneyModule.SampleMoneyModule.ValidateLandBuy"/>
+        /// Triggered in <see cref="MutSea.Region.Framework.Scenes.Scene.ProcessParcelBuy"/>
+        /// <seealso cref="MutSea.Region.OptionalModules.World.MoneyModule.SampleMoneyModule.ValidateLandBuy"/>
         /// </remarks>
         public event LandBuy OnValidateLandBuy;
 

--- a/OpenSim/Region/Framework/Scenes/GodController.cs
+++ b/OpenSim/Region/Framework/Scenes/GodController.cs
@@ -30,10 +30,10 @@ using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 //using log4net;
 using Nini.Config;
-using OpenSim.Framework;
+using MutSea.Framework;
 
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class GodController
     {

--- a/OpenSim/Region/Framework/Scenes/KeyframeMotion.cs
+++ b/OpenSim/Region/Framework/Scenes/KeyframeMotion.cs
@@ -34,16 +34,16 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using OpenSim.Region.Framework.Scenes.Serialization;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.PhysicsModules.SharedBase;
+using MutSea.Region.Framework.Scenes.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization;
 using Timer = System.Timers.Timer;
 using log4net;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class KeyframeTimer
     {

--- a/OpenSim/Region/Framework/Scenes/LinksetData.cs
+++ b/OpenSim/Region/Framework/Scenes/LinksetData.cs
@@ -36,7 +36,7 @@ using System.Xml;
 
 //using log4net;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class LinksetData
     {

--- a/OpenSim/Region/Framework/Scenes/Prioritizer.cs
+++ b/OpenSim/Region/Framework/Scenes/Prioritizer.cs
@@ -29,11 +29,11 @@ using System;
 using System.Collections.Generic;
 using log4net;
 using Nini.Config;
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Region.PhysicsModules.SharedBase;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public enum UpdatePrioritizationSchemes
     {

--- a/OpenSim/Region/Framework/Scenes/PriorityQueue.cs
+++ b/OpenSim/Region/Framework/Scenes/PriorityQueue.cs
@@ -29,9 +29,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class PriorityQueue
     {

--- a/OpenSim/Region/Framework/Scenes/RegionStatsHandler.cs
+++ b/OpenSim/Region/Framework/Scenes/RegionStatsHandler.cs
@@ -34,16 +34,16 @@ using log4net;
 using Nini.Config;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework;
-using OpenSim.Framework.Console;
-using OpenSim.Framework.Servers;
-using OpenSim.Framework.Servers.HttpServer;
-using OpenSim.Framework.Monitoring;
-using OpenSim.Region.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Framework.Console;
+using MutSea.Framework.Servers;
+using MutSea.Framework.Servers.HttpServer;
+using MutSea.Framework.Monitoring;
+using MutSea.Region.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class RegionStatsSimpleHandler : SimpleStreamHandler
     {
@@ -51,7 +51,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         private string osXStatsURI = String.Empty;
         //private string osSecret = String.Empty;
-        private OpenSim.Framework.RegionInfo regionInfo;
+        private MutSea.Framework.RegionInfo regionInfo;
         public string localZone = TimeZoneInfo.Local.StandardName;
         public TimeSpan utcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
 
@@ -102,7 +102,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         private string osXStatsURI = String.Empty;
         //private string osSecret = String.Empty;
-        private OpenSim.Framework.RegionInfo regionInfo;
+        private MutSea.Framework.RegionInfo regionInfo;
         public string localZone = TimeZoneInfo.Local.StandardName;
         public TimeSpan utcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
 

--- a/OpenSim/Region/Framework/Scenes/ReturnInfo.cs
+++ b/OpenSim/Region/Framework/Scenes/ReturnInfo.cs
@@ -27,7 +27,7 @@
 
 using OpenMetaverse;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public struct ReturnInfo
     {

--- a/OpenSim/Region/Framework/Scenes/SOPMaterial.cs
+++ b/OpenSim/Region/Framework/Scenes/SOPMaterial.cs
@@ -29,11 +29,11 @@ using System;
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography; // for computing md5 hash
-using OpenSim.Framework;
+using MutSea.Framework;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public static class SOPMaterialData
     {

--- a/OpenSim/Region/Framework/Scenes/SOPVehicle.cs
+++ b/OpenSim/Region/Framework/Scenes/SOPVehicle.cs
@@ -28,16 +28,16 @@
 using System;
 using System.Collections.Generic;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Region.PhysicsModules.SharedBase;
 using System.Text;
 using System.IO;
 using System.Xml;
-using OpenSim.Framework.Serialization;
-using OpenSim.Framework.Serialization.External;
-using OpenSim.Region.Framework.Scenes.Serialization;
+using MutSea.Framework.Serialization;
+using MutSea.Framework.Serialization.External;
+using MutSea.Region.Framework.Scenes.Serialization;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class SOPVehicle
     {

--- a/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Inventory.cs
@@ -33,13 +33,13 @@ using System.Text;
 using System.Xml;
 using OpenMetaverse;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Framework.Serialization.External;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Serialization;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using MutSea.Framework;
+using MutSea.Framework.Serialization.External;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Serialization;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public partial class Scene
     {

--- a/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.PacketHandlers.cs
@@ -31,10 +31,10 @@ using System.Collections.Concurrent;
 using System.Threading;
 using OpenMetaverse;
 using OpenMetaverse.Packets;
-using OpenSim.Framework;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Services.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public partial class Scene
     {

--- a/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.Permissions.cs
@@ -31,10 +31,10 @@ using System.Reflection;
 using System.Text;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     #region Delegates
     public delegate uint GenerateClientFlagsHandler(SceneObjectPart part, ScenePresence sp, uint curEffectivePerms);

--- a/OpenSim/Region/Framework/Scenes/Scene.cs
+++ b/OpenSim/Region/Framework/Scenes/Scene.cs
@@ -37,18 +37,18 @@ using System.Timers;
 using Nini.Config;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework;
-using OpenSim.Framework.Monitoring;
-using OpenSim.Services.Interfaces;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Serialization;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Framework.Monitoring;
+using MutSea.Services.Interfaces;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Serialization;
+using MutSea.Region.PhysicsModules.SharedBase;
 using Timer = System.Timers.Timer;
-using TPFlags = OpenSim.Framework.Constants.TeleportFlags;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using TPFlags = MutSea.Framework.Constants.TeleportFlags;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public delegate bool FilterAvatarList(ScenePresence avatar);
 
@@ -295,7 +295,7 @@ namespace OpenSim.Region.Framework.Scenes
         protected Timer m_timerWatchdog = new();
         protected List<RegionInfo> m_regionRestartNotifyList = new();
         protected List<RegionInfo> m_neighbours = new();
-        protected string m_simulatorVersion = "OpenSimulator Server";
+        protected string m_simulatorVersion = "MutSea Server";
         protected AgentCircuitManager m_authenticateHandler;
         protected SceneCommunicationService m_sceneGridService;
         protected ISnmpModule m_snmpService = null;
@@ -4341,7 +4341,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return false;
             }
 
-            OpenSim.Services.Interfaces.PresenceInfo pinfo = presencesvc.GetAgent(agent.SessionID);
+            MutSea.Services.Interfaces.PresenceInfo pinfo = presencesvc.GetAgent(agent.SessionID);
 
             if (pinfo is null)
             {

--- a/OpenSim/Region/Framework/Scenes/SceneBase.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneBase.cs
@@ -32,13 +32,13 @@ using System.Threading;
 using OpenMetaverse;
 using log4net;
 using Nini.Config;
-using OpenSim.Framework;
-using OpenSim.Framework.Console;
+using MutSea.Framework;
+using MutSea.Framework.Console;
 
-using OpenSim.Region.Framework.Interfaces;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using MutSea.Region.Framework.Interfaces;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public abstract class SceneBase : IScene
     {
@@ -263,7 +263,7 @@ namespace OpenSim.Region.Framework.Scenes
 
         public virtual string GetSimulatorVersion()
         {
-            return "OpenSimulator Server";
+            return "MutSea Server";
         }
 
         #endregion

--- a/OpenSim/Region/Framework/Scenes/SceneCommunicationService.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneCommunicationService.cs
@@ -33,15 +33,15 @@ using System.Threading;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Framework.Client;
-using OpenSim.Framework.Capabilities;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Framework.Client;
+using MutSea.Framework.Capabilities;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Services.Interfaces;
 using OSD = OpenMetaverse.StructuredData.OSD;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public delegate void RemoveKnownRegionsFromAvatarList(UUID avatarID, List<ulong> regionlst);
 
@@ -86,7 +86,7 @@ namespace OpenSim.Region.Framework.Scenes
                 // make a separate RegionFlags call but this would involve a network call for each neighbour.
                 if (n.RegionFlags != null)
                 {
-                    if ((n.RegionFlags & OpenSim.Framework.RegionFlags.RegionOnline) != 0)
+                    if ((n.RegionFlags & MutSea.Framework.RegionFlags.RegionOnline) != 0)
                         onlineNeighbours.Add(n.RegionHandle);
                 }
                 else

--- a/OpenSim/Region/Framework/Scenes/SceneGraph.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneGraph.cs
@@ -33,11 +33,11 @@ using System.Runtime.CompilerServices;
 using OpenMetaverse;
 using OpenMetaverse.Packets;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Region.PhysicsModules.SharedBase;
 using System.Runtime.InteropServices;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public delegate void PhysicsCrash();
     public delegate void AttachToBackupDelegate(SceneObjectGroup sog);
@@ -915,7 +915,7 @@ namespace OpenSim.Region.Framework.Scenes
         ///
         /// FIXME: The only user of the method right now is Caps.cs, in order to resolve a client API since it can't
         /// use the ScenePresence.  This could be better solved in a number of ways - we could establish an
-        /// OpenSim.Framework.IScenePresence, or move the caps code into a region package (which might be the more
+        /// MutSea.Framework.IScenePresence, or move the caps code into a region package (which might be the more
         /// suitable solution).
         /// </summary>
         /// <param name="agentId"></param>

--- a/OpenSim/Region/Framework/Scenes/SceneManager.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneManager.cs
@@ -31,10 +31,10 @@ using System.Net;
 using System.Reflection;
 using OpenMetaverse;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public delegate void RestartSim(RegionInfo thisregion);
 

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.Inventory.cs
@@ -29,13 +29,13 @@ using System;
 using System.Reflection;
 using OpenMetaverse;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 using System.Collections.Generic;
 using System.Xml;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public partial class SceneObjectGroup : EntityBase
     {

--- a/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectGroup.cs
@@ -27,10 +27,10 @@
 
 using OpenMetaverse;
 using OpenMetaverse.Packets;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Serialization;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Serialization;
+using MutSea.Region.PhysicsModules.SharedBase;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -38,9 +38,9 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Xml;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     // this is not the right place for this
     // for now it must match similar enums duplicated on scritp engines
@@ -777,7 +777,7 @@ namespace OpenSim.Region.Framework.Scenes
                 return sog;
 
             Vector3 newpos = Vector3.Zero;
-            OpenSim.Services.Interfaces.GridRegion destination = null;
+            MutSea.Services.Interfaces.GridRegion destination = null;
 
             destination = entityTransfer.GetObjectDestination(sog, val, out newpos);
             if (destination is null)

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPart.cs
@@ -38,13 +38,13 @@ using System.Xml.Serialization;
 using log4net;
 using OpenMetaverse;
 using OpenMetaverse.Packets;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Serialization;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Serialization;
+using MutSea.Region.PhysicsModules.SharedBase;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     #region Enumerations
 
@@ -2678,7 +2678,7 @@ namespace OpenSim.Region.Framework.Scenes
                 posVector = av.AbsolutePosition,
                 rotQuat = av.Rotation,
                 velVector = av.Velocity,
-                colliderType = av.IsNPC ? 0x20 : 0x1, // OpenSim\Region\ScriptEngine\Shared\Helpers.cs
+                colliderType = av.IsNPC ? 0x20 : 0x1, // MutSea.Region.ScriptEngine\Shared\Helpers.cs
                 groupUUID = av.ControllingClient.ActiveGroupId,
                 linkNumber = LinkNum
             };

--- a/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
+++ b/OpenSim/Region/Framework/Scenes/SceneObjectPartInventory.cs
@@ -33,11 +33,11 @@ using System.Collections;
 using System.Reflection;
 using OpenMetaverse;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using PermissionMask = OpenSim.Framework.PermissionMask;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using PermissionMask = MutSea.Framework.PermissionMask;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class SceneObjectPartInventory : IEntityInventory , IDisposable
     {

--- a/OpenSim/Region/Framework/Scenes/ScenePresence.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresence.cs
@@ -32,19 +32,19 @@ using System.Threading;
 using OpenMetaverse;
 using log4net;
 using Nini.Config;
-using OpenSim.Framework;
-using OpenSim.Framework.Client;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes.Animation;
-using OpenSim.Region.Framework.Scenes.Types;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
-using OpenSim.Services.Interfaces;
-using TeleportFlags = OpenSim.Framework.Constants.TeleportFlags;
+using MutSea.Framework;
+using MutSea.Framework.Client;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes.Animation;
+using MutSea.Region.Framework.Scenes.Types;
+using MutSea.Region.PhysicsModules.SharedBase;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
+using MutSea.Services.Interfaces;
+using TeleportFlags = MutSea.Framework.Constants.TeleportFlags;
 
 using ACFlags = OpenMetaverse.AgentManager.ControlFlags;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     [Flags]
     enum ScriptControlled : uint
@@ -6348,7 +6348,7 @@ namespace OpenSim.Region.Framework.Scenes
                 posVector = av.AbsolutePosition,
                 rotQuat = av.Rotation,
                 velVector = av.Velocity,
-                colliderType = av.IsNPC ? 0x20 : 0x1, // OpenSim\Region\ScriptEngine\Shared\Helpers.cs
+                colliderType = av.IsNPC ? 0x20 : 0x1, // MutSea.Region.ScriptEngine\Shared\Helpers.cs
                 groupUUID = av.ControllingClient.ActiveGroupId,
                 linkNumber = 0
             };

--- a/OpenSim/Region/Framework/Scenes/ScenePresenceStateMachine.cs
+++ b/OpenSim/Region/Framework/Scenes/ScenePresenceStateMachine.cs
@@ -27,7 +27,7 @@
 
 using System;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// The possible states that a scene presence can be in.  This is currently orthagonal to whether a scene presence

--- a/OpenSim/Region/Framework/Scenes/Scripting/ScriptUtils.cs
+++ b/OpenSim/Region/Framework/Scenes/Scripting/ScriptUtils.cs
@@ -26,9 +26,9 @@
  */
 
 using OpenMetaverse;
-using OpenSim.Framework;
+using MutSea.Framework;
 
-namespace OpenSim.Region.Framework.Scenes.Scripting
+namespace MutSea.Region.Framework.Scenes.Scripting
 {
     /// <summary>
     /// Utility functions for use by scripts manipulating the scene.

--- a/OpenSim/Region/Framework/Scenes/Serialization/CoalescedSceneObjectsSerializer.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/CoalescedSceneObjectsSerializer.cs
@@ -34,11 +34,11 @@ using System.Text;
 using System.Xml;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Scenes.Serialization
+namespace MutSea.Region.Framework.Scenes.Serialization
 {
     /// <summary>
     /// Serialize and deserialize coalesced scene objects.

--- a/OpenSim/Region/Framework/Scenes/Serialization/SceneObjectSerializer.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/SceneObjectSerializer.cs
@@ -34,15 +34,15 @@ using System.Reflection;
 using System.Xml;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Serialization.External;
+using MutSea.Framework;
+using MutSea.Framework.Serialization.External;
 
-namespace OpenSim.Region.Framework.Scenes.Serialization
+namespace MutSea.Region.Framework.Scenes.Serialization
 {
     /// <summary>
     /// Serialize and deserialize scene objects.
     /// </summary>
-    /// This should really be in OpenSim.Framework.Serialization but this would mean circular dependency problems
+    /// This should really be in MutSea.Framework.Serialization but this would mean circular dependency problems
     /// right now - hopefully this isn't forever.
     public class SceneObjectSerializer
     {

--- a/OpenSim/Region/Framework/Scenes/Serialization/SceneXmlLoader.cs
+++ b/OpenSim/Region/Framework/Scenes/Serialization/SceneXmlLoader.cs
@@ -32,11 +32,11 @@ using System.Reflection;
 using System.Xml;
 using OpenMetaverse;
 using log4net;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.PhysicsModules.SharedBase;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.PhysicsModules.SharedBase;
 
-namespace OpenSim.Region.Framework.Scenes.Serialization
+namespace MutSea.Region.Framework.Scenes.Serialization
 {
     /// <summary>
     /// Static methods to serialize and deserialize scene objects to and from XML

--- a/OpenSim/Region/Framework/Scenes/SimStatsReporter.cs
+++ b/OpenSim/Region/Framework/Scenes/SimStatsReporter.cs
@@ -30,11 +30,11 @@ using System.Collections.Generic;
 using System.Timers;
 using System.Threading;
 using OpenMetaverse.Packets;
-using OpenSim.Framework;
-using OpenSim.Framework.Monitoring;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Framework.Monitoring;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// Collect statistics from the scene to send to the client and for access by other monitoring tools.

--- a/OpenSim/Region/Framework/Scenes/TerrainChannel.cs
+++ b/OpenSim/Region/Framework/Scenes/TerrainChannel.cs
@@ -33,14 +33,14 @@ using System.Xml;
 using System.Xml.Serialization;
 
 using OpenSim.Data;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
 using OpenMetaverse;
 
 using log4net;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// A new version of the old Channel class, simplified

--- a/OpenSim/Region/Framework/Scenes/TerrainCompressor.cs
+++ b/OpenSim/Region/Framework/Scenes/TerrainCompressor.cs
@@ -37,12 +37,12 @@ using System.Collections.Generic;
 
 using log4net;
 
-using OpenSim.Framework;
+using MutSea.Framework;
 
 using OpenMetaverse;
 using OpenMetaverse.Packets;
 
-namespace OpenSim.Region.ClientStack.LindenUDP
+namespace MutSea.Region.ClientStack.LindenUDP
 {
     public static class OpenSimTerrainCompressor
     {

--- a/OpenSim/Region/Framework/Scenes/TerrainUtil.cs
+++ b/OpenSim/Region/Framework/Scenes/TerrainUtil.cs
@@ -26,9 +26,9 @@
  */
 
 using System;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public static class TerrainUtil
     {

--- a/OpenSim/Region/Framework/Scenes/Tests/EntityManagerTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/EntityManagerTests.cs
@@ -33,11 +33,11 @@ using System.Collections.Generic;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture, LongRunning]
     public class EntityManagerTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneGraphTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneGraphTests.cs
@@ -31,11 +31,11 @@ using System.Reflection;
 using System.Text;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneGraphTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneManagerTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneManagerTests.cs
@@ -31,12 +31,12 @@ using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneManagerTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectBasicTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectBasicTests.cs
@@ -32,12 +32,12 @@ using System.Threading;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Basic scene object tests (create, read and delete but not update).

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCopyTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCopyTests.cs
@@ -31,16 +31,16 @@ using System.Reflection;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.Framework.InventoryAccess;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.CoreModules.World.Permissions;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.Framework.InventoryAccess;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.CoreModules.World.Permissions;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /*
     /// <summary>

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCrossingTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectCrossingTests.cs
@@ -30,16 +30,16 @@ using System.Collections.Generic;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.CoreModules.World.Land;
-using OpenSim.Region.OptionalModules;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.CoreModules.World.Land;
+using MutSea.Region.OptionalModules;
+using MutSea.Tests.Common;
 using System.Threading;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     public class SceneObjectCrossingTests : OpenSimTestCase
     {

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectDeRezTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectDeRezTests.cs
@@ -31,16 +31,16 @@ using System.Reflection;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.Framework.InventoryAccess;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.CoreModules.World.Permissions;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.Framework.InventoryAccess;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.CoreModules.World.Permissions;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Tests derez of scene objects.

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectLinkingTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectLinkingTests.cs
@@ -30,12 +30,12 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 using log4net;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneObjectLinkingTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectResizeTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectResizeTests.cs
@@ -29,11 +29,11 @@ using System;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Basic scene object resize tests

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectScriptTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectScriptTests.cs
@@ -30,12 +30,12 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneObjectScriptTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectSerializationTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectSerializationTests.cs
@@ -34,14 +34,14 @@ using System.Linq;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Serialization.External;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Scenes.Serialization;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Framework.Serialization.External;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes.Serialization;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Basic scene object serialization tests.

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectSpatialTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectSpatialTests.cs
@@ -30,11 +30,11 @@ using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Spatial scene object tests (will eventually cover root and child part position, rotation properties, etc.)

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectStatusTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectStatusTests.cs
@@ -30,11 +30,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Basic scene object status tests

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectUndoRedoTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectUndoRedoTests.cs
@@ -30,11 +30,11 @@ using System;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Tests for undo/redo

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneObjectUserGroupTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneObjectUserGroupTests.cs
@@ -31,15 +31,15 @@ using System.Reflection;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.Avatar.InstantMessage;
-using OpenSim.Region.CoreModules.World.Permissions;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.Avatar.InstantMessage;
+using MutSea.Region.CoreModules.World.Permissions;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.OptionalModules.Avatar.XmlRpcGroups;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneObjectUserGroupTests

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAgentTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAgentTests.cs
@@ -35,18 +35,18 @@ using Timer = System.Timers.Timer;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.ClientStack.Linden;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.World.Serialiser;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Tests.Common;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.ClientStack.Linden;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.World.Serialiser;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Tests.Common;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
+using MutSea.Services.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Scene presence tests

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAnimationTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAnimationTests.cs
@@ -34,16 +34,16 @@ using System.Timers;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.World.Serialiser;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.World.Serialiser;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.PhysicsModules.SharedBase;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Scene presence animation tests

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAutopilotTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceAutopilotTests.cs
@@ -32,12 +32,12 @@ using log4net;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class ScenePresenceAutopilotTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCapabilityTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCapabilityTests.cs
@@ -35,20 +35,20 @@ using Timer = System.Timers.Timer;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Servers;
-using OpenSim.Framework.Servers.HttpServer;
-using OpenSim.Region.ClientStack.Linden;
-using OpenSim.Region.CoreModules.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.World.Serialiser;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Tests.Common;
-using GridRegion = OpenSim.Services.Interfaces.GridRegion;
+using MutSea.Framework;
+using MutSea.Framework.Servers;
+using MutSea.Framework.Servers.HttpServer;
+using MutSea.Region.ClientStack.Linden;
+using MutSea.Region.CoreModules.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.World.Serialiser;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Tests.Common;
+using GridRegion = MutSea.Services.Interfaces.GridRegion;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class ScenePresenceCapabilityTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCrossingTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceCrossingTests.cs
@@ -31,18 +31,18 @@ using System.Reflection;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Servers;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.CoreModules.World.Permissions;
-using OpenSim.Tests.Common;
-using OpenSim.Region.OptionalModules.Avatar.XmlRpcGroups;
+using MutSea.Framework;
+using MutSea.Framework.Servers;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.CoreModules.World.Permissions;
+using MutSea.Tests.Common;
+using MutSea.Region.OptionalModules.Avatar.XmlRpcGroups;
 using System.Threading;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class ScenePresenceCrossingTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceSitTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceSitTests.cs
@@ -31,14 +31,14 @@ using System.Reflection;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Servers;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Framework.Servers;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Tests.Common;
 using System.Threading;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class ScenePresenceSitTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceTeleportTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/ScenePresenceTeleportTests.cs
@@ -34,16 +34,16 @@ using System.Threading;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Framework.Servers;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.Framework;
-using OpenSim.Region.CoreModules.Framework.EntityTransfer;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Region.CoreModules.World.Permissions;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Framework.Servers;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.Framework;
+using MutSea.Region.CoreModules.Framework.EntityTransfer;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Region.CoreModules.World.Permissions;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Teleport tests in a standalone OpenSim

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneStatisticsTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneStatisticsTests.cs
@@ -30,11 +30,11 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class SceneStatisticsTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneTelehubTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneTelehubTests.cs
@@ -26,14 +26,14 @@ using System;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.World.Estate;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.World.Estate;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Scene telehub tests

--- a/OpenSim/Region/Framework/Scenes/Tests/SceneTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SceneTests.cs
@@ -35,14 +35,14 @@ using Timer=System.Timers.Timer;
 using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.World.Serialiser;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.World.Serialiser;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     /// <summary>
     /// Scene presence tests

--- a/OpenSim/Region/Framework/Scenes/Tests/SharedRegionModuleTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/SharedRegionModuleTests.cs
@@ -34,12 +34,12 @@ using NUnit.Framework;
 using OpenMetaverse;
 using OpenSim;
 using OpenSim.ApplicationPlugins.RegionModulesController;
-using OpenSim.Framework;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Grid;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Grid;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     public class SharedRegionModuleTests : OpenSimTestCase
     {
@@ -67,8 +67,8 @@ namespace OpenSim.Region.Framework.Scenes.Tests
             // For grid servic
             configSource.AddConfig("GridService");
             configSource.Configs["Modules"].Set("GridServices", "RegionGridServicesConnector");
-            configSource.Configs["GridService"].Set("StorageProvider", "OpenSim.Data.Null.dll:NullRegionData");
-            configSource.Configs["GridService"].Set("LocalServiceModule", "OpenSim.Services.GridService.dll:GridService");
+            configSource.Configs["GridService"].Set("StorageProvider", "MutSea.Data.Null.dll:NullRegionData");
+            configSource.Configs["GridService"].Set("LocalServiceModule", "MutSea.Services.GridService.dll:GridService");
             configSource.Configs["GridService"].Set("ConnectionString", "!static");
 
             RegionGridServicesConnector gridService = new RegionGridServicesConnector();

--- a/OpenSim/Region/Framework/Scenes/Tests/TaskInventoryTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/TaskInventoryTests.cs
@@ -36,16 +36,16 @@ using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
 using OpenMetaverse.Assets;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.CoreModules.Avatar.Inventory.Archiver;
-using OpenSim.Region.CoreModules.World.Serialiser;
-using OpenSim.Region.CoreModules.ServiceConnectorsOut.Simulation;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.Framework.Interfaces;
+using MutSea.Region.CoreModules.Avatar.Inventory.Archiver;
+using MutSea.Region.CoreModules.World.Serialiser;
+using MutSea.Region.CoreModules.ServiceConnectorsOut.Simulation;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Tests
+namespace MutSea.Region.Framework.Tests
 {
     [TestFixture]
     public class TaskInventoryTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/UserInventoryTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/UserInventoryTests.cs
@@ -36,13 +36,13 @@ using Nini.Config;
 using NUnit.Framework;
 using OpenMetaverse;
 using OpenMetaverse.Assets;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.CoreModules.Framework.InventoryAccess;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Region.CoreModules.Framework.InventoryAccess;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Tests
+namespace MutSea.Region.Framework.Tests
 {
     [TestFixture]
     public class UserInventoryTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Tests/UuidGathererTests.cs
+++ b/OpenSim/Region/Framework/Scenes/Tests/UuidGathererTests.cs
@@ -29,12 +29,12 @@ using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Services.Interfaces;
-using OpenSim.Tests.Common;
+using MutSea.Framework;
+using MutSea.Region.Framework.Scenes;
+using MutSea.Services.Interfaces;
+using MutSea.Tests.Common;
 
-namespace OpenSim.Region.Framework.Scenes.Tests
+namespace MutSea.Region.Framework.Scenes.Tests
 {
     [TestFixture]
     public class UuidGathererTests : OpenSimTestCase

--- a/OpenSim/Region/Framework/Scenes/Types/UpdateQueue.cs
+++ b/OpenSim/Region/Framework/Scenes/Types/UpdateQueue.cs
@@ -30,9 +30,9 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 using OpenMetaverse;
-using OpenSim.Region.Framework.Scenes;
+using MutSea.Region.Framework.Scenes;
 
-namespace OpenSim.Region.Framework.Scenes.Types
+namespace MutSea.Region.Framework.Scenes.Types
 {
     public class UpdateQueue
     {

--- a/OpenSim/Region/Framework/Scenes/UndoState.cs
+++ b/OpenSim/Region/Framework/Scenes/UndoState.cs
@@ -30,10 +30,10 @@ using System.Reflection;
 using System.Collections.Generic;
 using log4net;
 using OpenMetaverse;
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Interfaces;
+using MutSea.Framework;
+using MutSea.Region.Framework.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     public class UndoState
     {

--- a/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
+++ b/OpenSim/Region/Framework/Scenes/UuidGatherer.cs
@@ -33,10 +33,10 @@ using System.Text;
 using log4net;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-using OpenSim.Framework;
-using OpenSim.Services.Interfaces;
+using MutSea.Framework;
+using MutSea.Services.Interfaces;
 
-namespace OpenSim.Region.Framework.Scenes
+namespace MutSea.Region.Framework.Scenes
 {
     /// <summary>
     /// Gather uuids for a given entity.
@@ -256,7 +256,7 @@ namespace OpenSim.Region.Framework.Scenes
         protected Queue<UUID> m_assetUuidsToInspect;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OpenSim.Region.Framework.Scenes.UuidGatherer"/> class.
+        /// Initializes a new instance of the <see cref="MutSea.Region.Framework.Scenes.UuidGatherer"/> class.
         /// </summary>
         /// <remarks>In this case the collection of gathered assets will start out blank.</remarks>
         /// <param name="assetService">
@@ -268,7 +268,7 @@ namespace OpenSim.Region.Framework.Scenes
             new HashSet <UUID>(), new HashSet <UUID>()) {}
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OpenSim.Region.Framework.Scenes.UuidGatherer"/> class.
+        /// Initializes a new instance of the <see cref="MutSea.Region.Framework.Scenes.UuidGatherer"/> class.
         /// </summary>
         /// <param name="assetService">
         /// Asset service.


### PR DESCRIPTION
## Summary
- rename namespaces in `OpenSim/Region/Framework` classes from `OpenSim` to `MutSea`
- update assembly info to use `MutSea` identifiers
- adjust using statements and string references

## Testing
- `nant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8a3808508332960b02b8ba7ba906