### PR TITLE
Add log4net tracing

### DIFF
--- a/MutSea/Framework/Diagnostics/FunctionTracer.cs
+++ b/MutSea/Framework/Diagnostics/FunctionTracer.cs
@@ -27,6 +27,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Reflection;
+using log4net;
 
 namespace MutSea.Framework.Diagnostics
 {
@@ -35,6 +37,8 @@ namespace MutSea.Framework.Diagnostics
     /// </summary>
     public sealed class FunctionTracer : IDisposable
     {
+        private static readonly ILog m_log =
+            LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
         private readonly string m_name;
         private readonly Stopwatch m_timer;
 
@@ -65,13 +69,13 @@ namespace MutSea.Framework.Diagnostics
         {
             m_name = name;
             m_timer = Stopwatch.StartNew();
-            Console.WriteLine($"{DateTime.UtcNow:O} [TRACE ENTER] {name}");
+            m_log.Debug($"[TRACE ENTER] {name}");
         }
 
         public void Dispose()
         {
             m_timer.Stop();
-            Console.WriteLine($"{DateTime.UtcNow:O} [TRACE EXIT] {m_name} after {m_timer.Elapsed.TotalMilliseconds:F0} ms");
+            m_log.Debug($"[TRACE EXIT] {m_name} after {m_timer.Elapsed.TotalMilliseconds:F0} ms");
             GC.SuppressFinalize(this);
         }
     }

--- a/MutSea/Tests/FunctionTracerTests.cs
+++ b/MutSea/Tests/FunctionTracerTests.cs
@@ -16,6 +16,7 @@ namespace MutSea.Tests
             try
             {
                 Environment.SetEnvironmentVariable("MUTSEA_TRACE", "1");
+                TestLogging.LogToConsole();
 
                 using StringWriter sw = new StringWriter();
                 TextWriter oldOut = Console.Out;

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ one you set up using the "create user" command.
 
 MutSea provides a small helper called `FunctionTracer` for debugging. When
 enabled it logs when a function is entered and when it exits along with the
-elapsed time. Tracing is off by default. To turn it on, set the environment
-variable `MUTSEA_TRACE=1` before starting MutSea. You can then trace code by
+elapsed time. Messages are written using log4net, so they appear in
+`MutSea.log` alongside other server logs. Tracing is off by default. To turn it
+on, set the environment variable `MUTSEA_TRACE=1` before starting MutSea. You
+can then trace code by
 wrapping it with
 
 ```csharp


### PR DESCRIPTION
## Summary
- emit function tracer messages through log4net
- document log location in README
- adjust the FunctionTracer test for log4net output

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa1e037083329b782e1824c24ba7